### PR TITLE
File sector start addresses are 16 bits long (well, maybe only 9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.obj
+.project

--- a/tools/brother120tool.cc
+++ b/tools/brother120tool.cc
@@ -48,7 +48,7 @@ void readDirectory()
         std::unique_ptr<Dirent> dirent(new Dirent);
         dirent->filename = filename;
         dirent->type = buffer[8];
-        dirent->startSector = buffer[10];
+        dirent->startSector = buffer[9] * 256 + buffer[10];
         dirent->sectorCount = buffer[11];
         directory[filename] = std::move(dirent);
     }


### PR DESCRIPTION
Brother 120k starting sector addresses are actually two bytes long.  I'm sure there are prettier C++ish ways to express this, but there you go.