### PR TITLE
Fix build error on very old systems.

### DIFF
--- a/lib/bytes.h
+++ b/lib/bytes.h
@@ -4,42 +4,42 @@
 template <class T>
 inline uint32_t read_be16(T ptr)
 {
-    static_assert(sizeof(ptr[0]) == 1);
+    static_assert(sizeof(ptr[0]) == 1, "bad iterator type");
     return (ptr[0]<<8) | ptr[1];
 }
 
 template <class T>
 inline uint32_t read_be24(T ptr)
 {
-    static_assert(sizeof(ptr[0]) == 1);
+    static_assert(sizeof(ptr[0]) == 1, "bad iterator type");
     return (ptr[0]<<16) | (ptr[1]<<8) | ptr[2];
 }
 
 template <class T>
 inline uint32_t read_be32(T ptr)
 {
-    static_assert(sizeof(ptr[0]) == 1);
+    static_assert(sizeof(ptr[0]) == 1, "bad iterator type");
     return (ptr[0]<<24) | (ptr[1]<<16) | (ptr[2]<<8) | ptr[3];
 }
 
 template <class T>
 inline uint32_t read_le16(T ptr)
 {
-    static_assert(sizeof(ptr[0]) == 1);
+    static_assert(sizeof(ptr[0]) == 1, "bad iterator type");
     return (ptr[1]<<8) | ptr[0];
 }
 
 template <class T>
 inline uint32_t read_le32(T ptr)
 {
-    static_assert(sizeof(ptr[0]) == 1);
+    static_assert(sizeof(ptr[0]) == 1, "bad iterator type");
     return (ptr[3]<<24) | (ptr[2]<<16) | (ptr[1]<<8) | ptr[0];
 }
 
 template <class T>
 inline void write_le32(T ptr, uint32_t value)
 {
-    static_assert(sizeof(ptr[0]) == 1);
+    static_assert(sizeof(ptr[0]) == 1, "bad iterator type");
     ptr[0] = (value)     & 0xff;
     ptr[1] = (value>>8)  & 0xff;
     ptr[2] = (value>>16) & 0xff;

--- a/lib/ibm/decoder.cc
+++ b/lib/ibm/decoder.cc
@@ -6,7 +6,8 @@
 #include "sector.h"
 #include <string.h>
 
-static_assert(std::is_trivially_copyable<IbmIdam>::value);
+static_assert(std::is_trivially_copyable<IbmIdam>::value,
+		"IbmIdam is not trivially copyable");
 
 SectorVector AbstractIbmDecoder::decodeToSectors(const RawRecordVector& rawRecords, unsigned)
 {


### PR DESCRIPTION
Old C++ compilers don't like static_assert without a message.