### PR TITLE
Rework the way byte buffers are handled

### DIFF
--- a/lib/brother/brother.h
+++ b/lib/brother/brother.h
@@ -24,6 +24,6 @@ public:
 extern void writeBrotherSectorHeader(std::vector<bool>& bits, unsigned& cursor,
 		int track, int sector);
 extern void writeBrotherSectorData(std::vector<bool>& bits, unsigned& cursor,
-		const std::vector<uint8_t>& data);
+		const Bytes& data);
 
 #endif

--- a/lib/brother/decoder.cc
+++ b/lib/brother/decoder.cc
@@ -73,7 +73,8 @@ SectorVector BrotherDecoder::decodeToSectors(const RawRecordVector& rawRecords, 
 				if (rawrecord->data.size() < (32+32))
 					break;
 
-				ByteReader br(toBytes(ii+32, ii+64));
+				const auto& by = toBytes(ii+32, ii+64);
+				ByteReader br(by);
 				nextTrack = decode_header_gcr(br.read_be16());
 				nextSector = decode_header_gcr(br.read_be16());
 

--- a/lib/brother/encoder.cc
+++ b/lib/brother/encoder.cc
@@ -50,8 +50,7 @@ void writeBrotherSectorHeader(std::vector<bool>& bits, unsigned& cursor,
 	write_bits(bits, cursor, encode_header_gcr(0x2f), 16);
 }
 
-void writeBrotherSectorData(std::vector<bool>& bits, unsigned& cursor,
-		const std::vector<uint8_t>& data)
+void writeBrotherSectorData(std::vector<bool>& bits, unsigned& cursor, const Bytes& data)
 {
 	write_bits(bits, cursor, 0xffffffff, 32);
 	write_bits(bits, cursor, BROTHER_DATA_RECORD, 32);
@@ -80,7 +79,7 @@ void writeBrotherSectorData(std::vector<bool>& bits, unsigned& cursor,
 	for (uint8_t byte : data)
 		write_byte(byte);
 
-	uint32_t realCrc = crcbrother(&data[0], &data[256]);
+	uint32_t realCrc = crcbrother(data);
 	write_byte(realCrc>>16);
 	write_byte(realCrc>>8);
 	write_byte(realCrc);

--- a/lib/bytes.cc
+++ b/lib/bytes.cc
@@ -5,20 +5,19 @@
 
 static std::shared_ptr<std::vector<uint8_t>> createVector(unsigned size)
 {
-    std::shared_ptr<std::vector<uint8_t>> vector(new std::vector<uint8_t>(size));
-    return vector;
+    return std::make_shared<std::vector<uint8_t>>(size);
 }
 
 static std::shared_ptr<std::vector<uint8_t>> createVector(const uint8_t* ptr, unsigned size)
 {
-    std::shared_ptr<std::vector<uint8_t>> vector(new std::vector<uint8_t>(size));
+    auto vector = std::make_shared<std::vector<uint8_t>>(size);
     std::uninitialized_copy(ptr, ptr+size, vector->begin());
     return vector;
 }
 
 static std::shared_ptr<std::vector<uint8_t>> createVector(std::initializer_list<uint8_t> data)
 {
-    std::shared_ptr<std::vector<uint8_t>> vector(new std::vector<uint8_t>(data.size()));
+    auto vector = std::make_shared<std::vector<uint8_t>>(data.size());
     std::uninitialized_copy(data.begin(), data.end(), vector->begin());
     return vector;
 }
@@ -151,25 +150,11 @@ Bytes toBytes(
 {
     Bytes bytes;
     ByteWriter bw(bytes);
-    size_t bitcount = 0;
-    uint8_t fifo;
 
+    BitWriter bitw(bw);
     while (start != end)
-    {
-        fifo = (fifo<<1) | *start++;
-        bitcount++;
-        if (bitcount == 8)
-        {
-            bitcount = 0;
-            bw.write_8(fifo);
-        }
-    }
-
-    if (bitcount != 0)
-    {
-        fifo <<= 8-bitcount;
-        bw.write_8(fifo);
-    }
+        bitw.push(*start++, 1);
+    bitw.flush();
 
     return bytes;
 }

--- a/lib/bytes.cc
+++ b/lib/bytes.cc
@@ -96,9 +96,13 @@ void Bytes::adjustBounds(unsigned pos)
 
 Bytes& Bytes::resize(unsigned size)
 {
-    checkWritable();
+    unsigned oldsize = _high - _low;
+    if (size > oldsize)
+    {
+        checkWritable();
+        _data->resize(_low + size);
+    }
     _high = _low + size;
-    _data->resize(_high);
     return *this;
 }
 

--- a/lib/bytes.h
+++ b/lib/bytes.h
@@ -1,24 +1,26 @@
 #ifndef BYTES_H
 #define BYTES_H
 
+class ByteReader;
+class ByteWriter;
+
 class Bytes
 {
 public:
     Bytes();
     Bytes(unsigned size);
+    Bytes(const uint8_t* ptr, size_t len);
     Bytes(std::initializer_list<uint8_t> data);
     Bytes(std::shared_ptr<std::vector<uint8_t>> data);
     Bytes(std::shared_ptr<std::vector<uint8_t>> data, unsigned start, unsigned end);
 
-public:
     Bytes* operator = (const Bytes& other);
 
 public:
     /* General purpose methods */
 
-    uint8_t operator [] (unsigned offset) const;
-
     unsigned size() const        { return _high - _low; }
+    bool empty() const           { return _high == _low; }
 
     bool operator == (const Bytes& other) const
     { return std::equal(cbegin(), cend(), other.cbegin(), other.cend()); }
@@ -26,169 +28,239 @@ public:
     bool operator != (const Bytes& other) const
     { return !(*this == other); }
 
-    Bytes slice(unsigned start, unsigned len);
-
-    unsigned tell() const        { return _pos - _low; }
-    void seek(unsigned pos)      { _pos = pos + _low; }
-
-private:
-    void _boundsCheck(unsigned pos) const;
-    void _writableCheck() const;
-    void _adjustBounds(unsigned pos);
-
-    /* Read-only methods */
-
-public:
+    const uint8_t& operator [] (unsigned offset) const;
     const uint8_t* cbegin() const { return &(*_data)[_low]; }
     const uint8_t* cend() const   { return &(*_data)[_high]; }
+    const uint8_t* begin() const  { return &(*_data)[_low]; }
+    const uint8_t* end() const    { return &(*_data)[_high]; }
 
-    uint8_t read_8()
-    {
-        _boundsCheck(_pos);
-        return (*_data)[_pos++];
-    }
+    uint8_t& operator [] (unsigned offset);
+    uint8_t* begin()              { checkWritable(); return &(*_data)[_low]; }
+    uint8_t* end()                { checkWritable(); return &(*_data)[_high]; }
 
-    uint16_t read_be16()
-    {
-        _boundsCheck(_pos + 1);
-        uint8_t b1 = (*_data)[_pos++];
-        uint8_t b2 = (*_data)[_pos++];
-        return (b1<<8) | b2;
-    }
+    void boundsCheck(unsigned pos) const;
+    void checkWritable();
+    void adjustBounds(unsigned pos);
+    Bytes& resize(unsigned size);
 
-    uint32_t read_be24()
-    {
-        _boundsCheck(_pos + 2);
-        uint8_t b1 = (*_data)[_pos++];
-        uint8_t b2 = (*_data)[_pos++];
-        uint8_t b3 = (*_data)[_pos++];
-        return (b1<<16) | (b2<<8) | b3;
-    }
+    Bytes slice(unsigned start, unsigned len) const;
+    Bytes compress() const;
+    Bytes decompress() const;
 
-    uint32_t read_be32()
-    {
-        _boundsCheck(_pos + 3);
-        uint8_t b1 = (*_data)[_pos++];
-        uint8_t b2 = (*_data)[_pos++];
-        uint8_t b3 = (*_data)[_pos++];
-        uint8_t b4 = (*_data)[_pos++];
-        return (b1<<24) | (b2<<16) | (b3<<8) | b4;
-    }
-
-    uint16_t read_le16()
-    {
-        _boundsCheck(_pos + 1);
-        uint8_t b1 = (*_data)[_pos++];
-        uint8_t b2 = (*_data)[_pos++];
-        return (b2<<8) | b1;
-    }
-
-    uint32_t read_le24()
-    {
-        _boundsCheck(_pos + 2);
-        uint8_t b1 = (*_data)[_pos++];
-        uint8_t b2 = (*_data)[_pos++];
-        uint8_t b3 = (*_data)[_pos++];
-        return (b3<<16) | (b2<<8) | b1;
-    }
-
-    uint32_t read_le32()
-    {
-        _boundsCheck(_pos + 3);
-        uint8_t b1 = (*_data)[_pos++];
-        uint8_t b2 = (*_data)[_pos++];
-        uint8_t b3 = (*_data)[_pos++];
-        uint8_t b4 = (*_data)[_pos++];
-        return (b4<<24) | (b3<<16) | (b2<<8) | b1;
-    }
-
-    /* Writable methods */
-
-    uint8_t* begin() { return &(*_data)[_low]; }
-    uint8_t* end()   { return &(*_data)[_high]; }
-
-    Bytes& resize(unsigned size)
-    {
-        _writableCheck();
-        _high = _low + size;
-        _data->resize(_high);
-        return *this;
-    }
-
-    Bytes& write_8(uint8_t value)
-    {
-        _adjustBounds(_pos);
-        (*_data)[_pos++] = value;
-        return *this;
-    }
-
-    Bytes& write_be16(uint16_t value)
-    {
-        _adjustBounds(_pos+1);
-        (*_data)[_pos++] = value >> 8;
-        (*_data)[_pos++] = value;
-        return *this;
-    }
-
-    Bytes& write_be24(uint32_t value)
-    {
-        _adjustBounds(_pos+2);
-        (*_data)[_pos++] = value >> 16;
-        (*_data)[_pos++] = value >> 8;
-        (*_data)[_pos++] = value;
-        return *this;
-    }
-
-    Bytes& write_be32(uint32_t value)
-    {
-        _adjustBounds(_pos+3);
-        (*_data)[_pos++] = value >> 24;
-        (*_data)[_pos++] = value >> 16;
-        (*_data)[_pos++] = value >> 8;
-        (*_data)[_pos++] = value;
-        return *this;
-    }
-
-    Bytes& write_le16(uint16_t value)
-    {
-        _adjustBounds(_pos+1);
-        (*_data)[_pos++] = value;
-        (*_data)[_pos++] = value >> 8;
-        return *this;
-    }
-
-    Bytes& write_le24(uint32_t value)
-    {
-        _adjustBounds(_pos+2);
-        (*_data)[_pos++] = value;
-        (*_data)[_pos++] = value >> 8;
-        (*_data)[_pos++] = value >> 16;
-        return *this;
-    }
-
-    Bytes& write_le32(uint32_t value)
-    {
-        _adjustBounds(_pos+3);
-        (*_data)[_pos++] = value;
-        (*_data)[_pos++] = value >> 8;
-        (*_data)[_pos++] = value >> 16;
-        (*_data)[_pos++] = value >> 24;
-        return *this;
-    }
-
-    Bytes& write(std::initializer_list<uint8_t> data)
-    {
-        _adjustBounds(_pos + data.size() - 1);
-        std::copy(data.begin(), data.end(), &(*_data)[_pos]);
-        _pos += data.size();
-        return *this;
-    }
+    ByteReader reader() const;
+    ByteWriter writer();
 
 private:
     std::shared_ptr<std::vector<uint8_t>> _data;
     unsigned _low;
     unsigned _high;
-    unsigned _pos;
+};
+
+class ByteReader
+{
+public:
+    ByteReader(const Bytes& bytes):
+        _bytes(bytes)
+    {}
+
+    unsigned pos = 0;
+    bool eof() const
+    { return pos == _bytes.size(); }
+
+    ByteReader& seek(unsigned pos)
+    {
+        this->pos = pos;
+        return *this;
+    }
+
+    uint8_t read_8()
+    {
+        return _bytes[pos++];
+    }
+
+    uint16_t read_be16()
+    {
+        uint8_t b1 = _bytes[pos++];
+        uint8_t b2 = _bytes[pos++];
+        return (b1<<8) | b2;
+    }
+
+    uint32_t read_be24()
+    {
+        uint8_t b1 = _bytes[pos++];
+        uint8_t b2 = _bytes[pos++];
+        uint8_t b3 = _bytes[pos++];
+        return (b1<<16) | (b2<<8) | b3;
+    }
+
+    uint32_t read_be32()
+    {
+        uint8_t b1 = _bytes[pos++];
+        uint8_t b2 = _bytes[pos++];
+        uint8_t b3 = _bytes[pos++];
+        uint8_t b4 = _bytes[pos++];
+        return (b1<<24) | (b2<<16) | (b3<<8) | b4;
+    }
+
+    uint16_t read_le16()
+    {
+        uint8_t b1 = _bytes[pos++];
+        uint8_t b2 = _bytes[pos++];
+        return (b2<<8) | b1;
+    }
+
+    uint32_t read_le24()
+    {
+        uint8_t b1 = _bytes[pos++];
+        uint8_t b2 = _bytes[pos++];
+        uint8_t b3 = _bytes[pos++];
+        return (b3<<16) | (b2<<8) | b1;
+    }
+
+    uint32_t read_le32()
+    {
+        uint8_t b1 = _bytes[pos++];
+        uint8_t b2 = _bytes[pos++];
+        uint8_t b3 = _bytes[pos++];
+        uint8_t b4 = _bytes[pos++];
+        return (b4<<24) | (b3<<16) | (b2<<8) | b1;
+    }
+
+private:
+    const Bytes& _bytes;
+};
+
+class ByteWriter
+{
+public:
+    ByteWriter(Bytes& bytes):
+        _bytes(bytes)
+    {}
+
+    unsigned pos = 0;
+
+    ByteWriter& seek(unsigned pos)
+    {
+        this->pos = pos;
+        return *this;
+    }
+
+    ByteWriter& seekToEnd()
+    {
+        pos = _bytes.size();
+        return *this;
+    }
+
+    ByteWriter& write_8(uint8_t value)
+    {
+        _bytes.adjustBounds(pos);
+        uint8_t* p = _bytes.begin();
+        p[pos++] = value;
+        return *this;
+    }
+
+    ByteWriter& write_be16(uint16_t value)
+    {
+        _bytes.adjustBounds(pos+1);
+        uint8_t* p = _bytes.begin();
+        p[pos++] = value >> 8;
+        p[pos++] = value;
+        return *this;
+    }
+
+    ByteWriter& write_be24(uint32_t value)
+    {
+        _bytes.adjustBounds(pos+2);
+        uint8_t* p = _bytes.begin();
+        p[pos++] = value >> 16;
+        p[pos++] = value >> 8;
+        p[pos++] = value;
+        return *this;
+    }
+
+    ByteWriter& write_be32(uint32_t value)
+    {
+        _bytes.adjustBounds(pos+3);
+        uint8_t* p = _bytes.begin();
+        p[pos++] = value >> 24;
+        p[pos++] = value >> 16;
+        p[pos++] = value >> 8;
+        p[pos++] = value;
+        return *this;
+    }
+
+    ByteWriter& write_le16(uint16_t value)
+    {
+        _bytes.adjustBounds(pos+1);
+        uint8_t* p = _bytes.begin();
+        p[pos++] = value;
+        p[pos++] = value >> 8;
+        return *this;
+    }
+
+    ByteWriter& write_le24(uint32_t value)
+    {
+        _bytes.adjustBounds(pos+2);
+        uint8_t* p = _bytes.begin();
+        p[pos++] = value;
+        p[pos++] = value >> 8;
+        p[pos++] = value >> 16;
+        return *this;
+    }
+
+    ByteWriter& write_le32(uint32_t value)
+    {
+        _bytes.adjustBounds(pos+3);
+        uint8_t* p = _bytes.begin();
+        p[pos++] = value;
+        p[pos++] = value >> 8;
+        p[pos++] = value >> 16;
+        p[pos++] = value >> 24;
+        return *this;
+    }
+
+    ByteWriter& operator += (std::initializer_list<uint8_t> data)
+    {
+        _bytes.adjustBounds(pos + data.size() - 1);
+        std::copy(data.begin(), data.end(), _bytes.begin() + pos);
+        pos += data.size();
+        return *this;
+    }
+
+    ByteWriter& operator += (const std::vector<uint8_t>& data)
+    {
+        _bytes.adjustBounds(pos + data.size() - 1);
+        std::copy(data.begin(), data.end(), _bytes.begin() + pos);
+        pos += data.size();
+        return *this;
+    }
+
+    ByteWriter& operator += (const Bytes data)
+    {
+        _bytes.adjustBounds(pos + data.size() - 1);
+        std::copy(data.begin(), data.end(), _bytes.begin() + pos);
+        pos += data.size();
+        return *this;
+    }
+
+private:
+    Bytes& _bytes;
+};
+
+class BitWriter
+{
+public:
+    BitWriter(ByteWriter& bw):
+        _bw(bw)
+    {}
+
+    void push(uint32_t bits, size_t size);
+    void flush();
+
+private:
+    uint8_t _fifo;
+    size_t _bitcount = 0;
+    ByteWriter& _bw;
 };
 
 static inline uint8_t reverse_bits(uint8_t b)
@@ -199,83 +271,15 @@ static inline uint8_t reverse_bits(uint8_t b)
     return b;
 }
 
-template <class T>
-inline uint32_t read_be16(T ptr)
-{
-    static_assert(sizeof(ptr[0]) == 1, "bad iterator type");
-    return (ptr[0]<<8) | ptr[1];
-}
-
-template <class T>
-inline uint32_t read_be24(T ptr)
-{
-    static_assert(sizeof(ptr[0]) == 1, "bad iterator type");
-    return (ptr[0]<<16) | (ptr[1]<<8) | ptr[2];
-}
-
-template <class T>
-inline uint32_t read_be32(T ptr)
-{
-    static_assert(sizeof(ptr[0]) == 1, "bad iterator type");
-    return (ptr[0]<<24) | (ptr[1]<<16) | (ptr[2]<<8) | ptr[3];
-}
-
-template <class T>
-inline uint32_t read_le16(T ptr)
-{
-    static_assert(sizeof(ptr[0]) == 1, "bad iterator type");
-    return (ptr[1]<<8) | ptr[0];
-}
-
-template <class T>
-inline uint32_t read_le32(T ptr)
-{
-    static_assert(sizeof(ptr[0]) == 1, "bad iterator type");
-    return (ptr[3]<<24) | (ptr[2]<<16) | (ptr[1]<<8) | ptr[0];
-}
-
-template <class T>
-inline void write_le32(T ptr, uint32_t value)
-{
-    static_assert(sizeof(ptr[0]) == 1, "bad iterator type");
-    ptr[0] = (value)     & 0xff;
-    ptr[1] = (value>>8)  & 0xff;
-    ptr[2] = (value>>16) & 0xff;
-    ptr[3] = (value>>24) & 0xff;
-}
-
 extern uint8_t toByte(
     std::vector<bool>::const_iterator start,
     std::vector<bool>::const_iterator end);
 
-extern std::vector<uint8_t> toBytes(
+extern Bytes toBytes(
     std::vector<bool>::const_iterator start,
     std::vector<bool>::const_iterator end);
 
-inline std::vector<uint8_t> toBytes(const std::vector<bool>& bits)
+inline Bytes toBytes(const std::vector<bool>& bits)
 { return toBytes(bits.begin(), bits.end()); }
-
-extern std::vector<uint8_t> compress(const std::vector<uint8_t>& source);
-extern std::vector<uint8_t> decompress(const std::vector<uint8_t>& source);
-
-class BitAccumulator
-{
-public:
-    BitAccumulator()
-    { reset(); }
-
-    void reset();
-    void push(uint32_t bits, size_t size);
-    size_t size() const { return _data.size(); }
-    void finish();
-
-    operator const std::vector<uint8_t>& ()
-    { finish(); return _data; }
-
-private:
-    uint8_t _fifo;
-    size_t _bitcount;
-    std::vector<uint8_t> _data;
-};
 
 #endif

--- a/lib/bytes.h
+++ b/lib/bytes.h
@@ -63,6 +63,8 @@ public:
         _bytes(bytes)
     {}
 
+    ByteReader(const Bytes&&) = delete;
+
     unsigned pos = 0;
     bool eof() const
     { return pos == _bytes.size(); }
@@ -136,6 +138,8 @@ public:
     ByteWriter(Bytes& bytes):
         _bytes(bytes)
     {}
+
+    ByteWriter(const Bytes&&) = delete;
 
     unsigned pos = 0;
 
@@ -253,6 +257,8 @@ public:
     BitWriter(ByteWriter& bw):
         _bw(bw)
     {}
+
+    BitWriter(ByteWriter&&) = delete;
 
     void push(uint32_t bits, size_t size);
     void flush();

--- a/lib/bytes.h
+++ b/lib/bytes.h
@@ -1,6 +1,196 @@
 #ifndef BYTES_H
 #define BYTES_H
 
+class Bytes
+{
+public:
+    Bytes();
+    Bytes(unsigned size);
+    Bytes(std::initializer_list<uint8_t> data);
+    Bytes(std::shared_ptr<std::vector<uint8_t>> data);
+    Bytes(std::shared_ptr<std::vector<uint8_t>> data, unsigned start, unsigned end);
+
+public:
+    Bytes* operator = (const Bytes& other);
+
+public:
+    /* General purpose methods */
+
+    uint8_t operator [] (unsigned offset) const;
+
+    unsigned size() const        { return _high - _low; }
+
+    bool operator == (const Bytes& other) const
+    { return std::equal(cbegin(), cend(), other.cbegin(), other.cend()); }
+
+    bool operator != (const Bytes& other) const
+    { return !(*this == other); }
+
+    Bytes slice(unsigned start, unsigned len);
+
+    unsigned tell() const        { return _pos - _low; }
+    void seek(unsigned pos)      { _pos = pos + _low; }
+
+private:
+    void _boundsCheck(unsigned pos) const;
+    void _writableCheck() const;
+    void _adjustBounds(unsigned pos);
+
+    /* Read-only methods */
+
+public:
+    const uint8_t* cbegin() const { return &(*_data)[_low]; }
+    const uint8_t* cend() const   { return &(*_data)[_high]; }
+
+    uint8_t read_8()
+    {
+        _boundsCheck(_pos);
+        return (*_data)[_pos++];
+    }
+
+    uint16_t read_be16()
+    {
+        _boundsCheck(_pos + 1);
+        uint8_t b1 = (*_data)[_pos++];
+        uint8_t b2 = (*_data)[_pos++];
+        return (b1<<8) | b2;
+    }
+
+    uint32_t read_be24()
+    {
+        _boundsCheck(_pos + 2);
+        uint8_t b1 = (*_data)[_pos++];
+        uint8_t b2 = (*_data)[_pos++];
+        uint8_t b3 = (*_data)[_pos++];
+        return (b1<<16) | (b2<<8) | b3;
+    }
+
+    uint32_t read_be32()
+    {
+        _boundsCheck(_pos + 3);
+        uint8_t b1 = (*_data)[_pos++];
+        uint8_t b2 = (*_data)[_pos++];
+        uint8_t b3 = (*_data)[_pos++];
+        uint8_t b4 = (*_data)[_pos++];
+        return (b1<<24) | (b2<<16) | (b3<<8) | b4;
+    }
+
+    uint16_t read_le16()
+    {
+        _boundsCheck(_pos + 1);
+        uint8_t b1 = (*_data)[_pos++];
+        uint8_t b2 = (*_data)[_pos++];
+        return (b2<<8) | b1;
+    }
+
+    uint32_t read_le24()
+    {
+        _boundsCheck(_pos + 2);
+        uint8_t b1 = (*_data)[_pos++];
+        uint8_t b2 = (*_data)[_pos++];
+        uint8_t b3 = (*_data)[_pos++];
+        return (b3<<16) | (b2<<8) | b1;
+    }
+
+    uint32_t read_le32()
+    {
+        _boundsCheck(_pos + 3);
+        uint8_t b1 = (*_data)[_pos++];
+        uint8_t b2 = (*_data)[_pos++];
+        uint8_t b3 = (*_data)[_pos++];
+        uint8_t b4 = (*_data)[_pos++];
+        return (b4<<24) | (b3<<16) | (b2<<8) | b1;
+    }
+
+    /* Writable methods */
+
+    uint8_t* begin() { return &(*_data)[_low]; }
+    uint8_t* end()   { return &(*_data)[_high]; }
+
+    Bytes& resize(unsigned size)
+    {
+        _writableCheck();
+        _high = _low + size;
+        _data->resize(_high);
+        return *this;
+    }
+
+    Bytes& write_8(uint8_t value)
+    {
+        _adjustBounds(_pos);
+        (*_data)[_pos++] = value;
+        return *this;
+    }
+
+    Bytes& write_be16(uint16_t value)
+    {
+        _adjustBounds(_pos+1);
+        (*_data)[_pos++] = value >> 8;
+        (*_data)[_pos++] = value;
+        return *this;
+    }
+
+    Bytes& write_be24(uint32_t value)
+    {
+        _adjustBounds(_pos+2);
+        (*_data)[_pos++] = value >> 16;
+        (*_data)[_pos++] = value >> 8;
+        (*_data)[_pos++] = value;
+        return *this;
+    }
+
+    Bytes& write_be32(uint32_t value)
+    {
+        _adjustBounds(_pos+3);
+        (*_data)[_pos++] = value >> 24;
+        (*_data)[_pos++] = value >> 16;
+        (*_data)[_pos++] = value >> 8;
+        (*_data)[_pos++] = value;
+        return *this;
+    }
+
+    Bytes& write_le16(uint16_t value)
+    {
+        _adjustBounds(_pos+1);
+        (*_data)[_pos++] = value;
+        (*_data)[_pos++] = value >> 8;
+        return *this;
+    }
+
+    Bytes& write_le24(uint32_t value)
+    {
+        _adjustBounds(_pos+2);
+        (*_data)[_pos++] = value;
+        (*_data)[_pos++] = value >> 8;
+        (*_data)[_pos++] = value >> 16;
+        return *this;
+    }
+
+    Bytes& write_le32(uint32_t value)
+    {
+        _adjustBounds(_pos+3);
+        (*_data)[_pos++] = value;
+        (*_data)[_pos++] = value >> 8;
+        (*_data)[_pos++] = value >> 16;
+        (*_data)[_pos++] = value >> 24;
+        return *this;
+    }
+
+    Bytes& write(std::initializer_list<uint8_t> data)
+    {
+        _adjustBounds(_pos + data.size() - 1);
+        std::copy(data.begin(), data.end(), &(*_data)[_pos]);
+        _pos += data.size();
+        return *this;
+    }
+
+private:
+    std::shared_ptr<std::vector<uint8_t>> _data;
+    unsigned _low;
+    unsigned _high;
+    unsigned _pos;
+};
+
 static inline uint8_t reverse_bits(uint8_t b)
 {
     b = (b & 0xF0) >> 4 | (b & 0x0F) << 4;

--- a/lib/c64/c64.h
+++ b/lib/c64/c64.h
@@ -2,6 +2,7 @@
 #define C64_H
 
 #define C64_RECORD_SEPARATOR 0xfff5
+#define C64_SECTOR_LENGTH    256
 
 class Sector;
 class Fluxmap;

--- a/lib/crc.cc
+++ b/lib/crc.cc
@@ -58,14 +58,13 @@ uint32_t crcbrother(const Bytes& bytes)
 {
 	ByteReader br(bytes);
 
-	uint32_t crc = 0;
-	do
+	uint32_t crc = br.read_8();
+	while (!br.eof())
 	{
-		crc ^= br.read_8();
 		for (int i=0; i<8; i++)
 			crc = (crc & 0x800000) ? ((crc<<1)^BROTHER_POLY) : (crc<<1);
+		crc ^= br.read_8();
 	}
-	while (!br.eof());
 
 	return crc & 0xFFFFFF;
 }

--- a/lib/crc.cc
+++ b/lib/crc.cc
@@ -1,29 +1,35 @@
 #include "globals.h"
+#include "bytes.h"
 #include "crc.h"
 
-uint16_t sumBytes(const uint8_t* start, const uint8_t* end)
+uint16_t sumBytes(const Bytes& bytes)
 {
+	ByteReader br(bytes);
+
 	uint16_t i = 0;
-	while (start != end)
-		i += *start++;
+	while (!br.eof())
+		i += br.read_8();
 	return i;
 }
 
-uint8_t xorBytes(const uint8_t* start, const uint8_t* end)
+uint8_t xorBytes(const Bytes& bytes)
 {
+	ByteReader br(bytes);
+
 	uint8_t i = 0;
-	while (start != end)
-		i ^= *start++;
+	while (!br.eof())
+		i ^= br.read_8();
 	return i;
 }
 
-uint16_t crc16(uint16_t poly, const uint8_t* start, const uint8_t* end)
+uint16_t crc16(uint16_t poly, const Bytes& bytes)
 {
-	uint16_t crc = 0xffff;
+	ByteReader br(bytes);
 
-	while (start != end)
+	uint16_t crc = 0xffff;
+	while (!br.eof())
 	{
-		crc ^= *start++ << 8;
+		crc ^= br.read_8() << 8;
 		for (int i=0; i<8; i++)
 			crc = (crc & 0x8000) ? ((crc<<1)^poly) : (crc<<1);
 	}
@@ -31,13 +37,14 @@ uint16_t crc16(uint16_t poly, const uint8_t* start, const uint8_t* end)
 	return crc;
 }
 
-uint16_t crc16ref(uint16_t poly, const uint8_t* start, const uint8_t* end)
+uint16_t crc16ref(uint16_t poly, const Bytes& bytes)
 {
-	uint16_t crc = 0xffff;
+	ByteReader br(bytes);
 
-	while (start != end)
+	uint16_t crc = 0xffff;
+	while (!br.eof())
 	{
-		crc ^= *start++;
+		crc ^= br.read_8();
 		for (int i=0; i<8; i++)
 			crc = (crc & 0x0001) ? ((crc>>1)^poly) : (crc>>1);
 	}
@@ -47,16 +54,18 @@ uint16_t crc16ref(uint16_t poly, const uint8_t* start, const uint8_t* end)
 
 /* Thanks to user202729 on StackOverflow for miraculously reverse engineering
  * this. */
-uint32_t crcbrother(const uint8_t* start, const uint8_t* end)
+uint32_t crcbrother(const Bytes& bytes)
 {
-	uint32_t crc = *start++;
+	ByteReader br(bytes);
 
-	while (start != end)
+	uint32_t crc = 0;
+	do
 	{
+		crc ^= br.read_8();
 		for (int i=0; i<8; i++)
 			crc = (crc & 0x800000) ? ((crc<<1)^BROTHER_POLY) : (crc<<1);
-		crc ^= *start++;
 	}
+	while (!br.eof());
 
 	return crc & 0xFFFFFF;
 }

--- a/lib/crc.h
+++ b/lib/crc.h
@@ -6,11 +6,11 @@
 #define MODBUS_POLY_REF 0xa001
 #define BROTHER_POLY    0x000201
 
-extern uint16_t sumBytes(const uint8_t* start, const uint8_t* end);
-extern uint8_t xorBytes(const uint8_t* start, const uint8_t* end);
-extern uint16_t crc16(uint16_t poly, const uint8_t* start, const uint8_t* end);
-extern uint16_t crc16ref(uint16_t poly, const uint8_t* start, const uint8_t* end);
-extern uint32_t crcbrother(const uint8_t* start, const uint8_t* end);
+extern uint16_t sumBytes(const Bytes& bytes);
+extern uint8_t xorBytes(const Bytes& bytes);
+extern uint16_t crc16(uint16_t poly, const Bytes& bytes);
+extern uint16_t crc16ref(uint16_t poly, const Bytes& bytes);
+extern uint32_t crcbrother(const Bytes& bytes);
 
 #endif
 

--- a/lib/decoders/decoders.h
+++ b/lib/decoders/decoders.h
@@ -2,7 +2,7 @@
 #define DECODERS_H
 
 #include "segmenter.h"
-
+#include "bytes.h"
 
 class Sector;
 class Fluxmap;
@@ -10,7 +10,7 @@ class RawRecord;
 typedef std::vector<std::unique_ptr<RawRecord>> RawRecordVector;
 typedef std::vector<std::unique_ptr<Sector>> SectorVector;
 
-extern std::vector<uint8_t> decodeFmMfm(const std::vector<bool> bits);
+extern Bytes decodeFmMfm(const std::vector<bool> bits);
 
 class AbstractDecoder : public AbstractSegmenter
 {

--- a/lib/decoders/fmmfm.cc
+++ b/lib/decoders/fmmfm.cc
@@ -1,7 +1,7 @@
 #include "globals.h"
 #include "decoders.h"
 
-std::vector<uint8_t> decodeFmMfm(const std::vector<bool> bits)
+Bytes decodeFmMfm(const std::vector<bool> bits)
 {
     /* 
      * FM is dumb as rocks, consisting on regular clock pulses with data pulses in
@@ -21,7 +21,9 @@ std::vector<uint8_t> decodeFmMfm(const std::vector<bool> bits)
      * decoding MFM uses just the same code!
      */
 
-    std::vector<uint8_t> bytes;
+    Bytes bytes;
+    ByteWriter bw(bytes);
+
     size_t cursor = 1;
     int bitcount = 0;
     uint8_t fifo;
@@ -33,7 +35,7 @@ std::vector<uint8_t> decodeFmMfm(const std::vector<bool> bits)
         bitcount++;
         if (bitcount == 8)
         {
-            bytes.push_back(fifo);
+            bw.write_8(fifo);
             bitcount = 0;
         }
     }
@@ -41,7 +43,7 @@ std::vector<uint8_t> decodeFmMfm(const std::vector<bool> bits)
     if (bitcount != 0)
     {
         fifo <<= 8-bitcount;
-        bytes.push_back(fifo);
+        bw.write_8(fifo);
     }
 
     return bytes;

--- a/lib/fluxmap.cc
+++ b/lib/fluxmap.cc
@@ -17,18 +17,21 @@ uint32_t Fluxmap::getAndIncrement(size_t& index) const
     return ticks;
 }
 
-Fluxmap& Fluxmap::appendBytes(const std::vector<uint8_t>& bytes)
+Fluxmap& Fluxmap::appendBytes(const Bytes& bytes)
 {
     return appendBytes(&bytes[0], bytes.size());
 }
 
 Fluxmap& Fluxmap::appendBytes(const uint8_t* ptr, size_t len)
 {
+    ByteWriter bw(_bytes);
+    bw.seekToEnd();
+
     while (len--)
     {
         uint8_t byte = *ptr++;
         _ticks += byte;
-        _bytes.push_back(byte);
+        bw.write_8(byte);
     }
 
     _duration = _ticks * NS_PER_TICK;
@@ -53,26 +56,26 @@ void Fluxmap::precompensate(int threshold_ticks, int amount_ticks)
     for (unsigned i=0; i<_bytes.size(); i++)
     {
         uint8_t& prev = (i == 0) ? junk : _bytes[i-1];
-        uint8_t& curr = _bytes[i];
+        uint8_t curr = _bytes[i];
 
-        if (curr > (3*threshold_ticks))
-            continue;
-
-        if ((prev <= threshold_ticks) && (curr > threshold_ticks))
+        if (curr < (3*threshold_ticks))
         {
-            /* 01001; move the previous bit backwards. */
-            if (prev >= (1+amount_ticks))
-                prev -= amount_ticks;
-            if (curr <= (0x7f-amount_ticks))
-                curr += amount_ticks;
-        }
-        else if ((prev > threshold_ticks) && (curr <= threshold_ticks))
-        {
-            /* 00101; move the current bit forwards. */
-            if (prev <= (0x7f-amount_ticks))
-                prev += amount_ticks;
-            if (curr >= (1+amount_ticks))
-                curr -= amount_ticks;
+            if ((prev <= threshold_ticks) && (curr > threshold_ticks))
+            {
+                /* 01001; move the previous bit backwards. */
+                if (prev >= (1+amount_ticks))
+                    prev -= amount_ticks;
+                if (curr <= (0x7f-amount_ticks))
+                    curr += amount_ticks;
+            }
+            else if ((prev > threshold_ticks) && (curr <= threshold_ticks))
+            {
+                /* 00101; move the current bit forwards. */
+                if (prev <= (0x7f-amount_ticks))
+                    prev += amount_ticks;
+                if (curr >= (1+amount_ticks))
+                    curr -= amount_ticks;
+            }
         }
     }
 }

--- a/lib/fluxmap.h
+++ b/lib/fluxmap.h
@@ -1,6 +1,8 @@
 #ifndef FLUXMAP_H
 #define FLUXMAP_H
 
+#include "bytes.h"
+
 class Fluxmap
 {
 public:
@@ -8,18 +10,18 @@ public:
 
     nanoseconds_t duration() const { return _duration; }
     size_t bytes() const { return _bytes.size(); }
-    const std::vector<uint8_t> rawBytes() const { return _bytes; }
+    const Bytes& rawBytes() const { return _bytes; }
 
     const uint8_t* ptr() const
 	{
 		if (!_bytes.empty())
-			return &_bytes.at(0);
+			return &_bytes[0];
 		return NULL;
 	}
 
     Fluxmap& appendInterval(uint32_t ticks);
 
-    Fluxmap& appendBytes(const std::vector<uint8_t>& bytes);
+    Fluxmap& appendBytes(const Bytes& bytes);
     Fluxmap& appendBytes(const uint8_t* ptr, size_t len);
 
     Fluxmap& appendByte(uint8_t byte)
@@ -37,7 +39,7 @@ public:
 private:
     nanoseconds_t _duration = 0;
     int _ticks = 0;
-    std::vector<uint8_t> _bytes;
+    Bytes _bytes;
 };
 
 #endif

--- a/lib/globals.h
+++ b/lib/globals.h
@@ -13,9 +13,10 @@
 #include <cassert>
 
 typedef int nanoseconds_t;
+class Bytes;
 
 extern double getCurrentTime();
-extern void hexdump(std::ostream& stream, const std::vector<uint8_t>& buffer);
+extern void hexdump(std::ostream& stream, const Bytes& bytes);
 
 class Error
 {

--- a/lib/hexdump.cc
+++ b/lib/hexdump.cc
@@ -1,7 +1,8 @@
 #include "globals.h"
+#include "bytes.h"
 #include "fmt/format.h"
 
-void hexdump(std::ostream& stream, const std::vector<uint8_t>& buffer)
+void hexdump(std::ostream& stream, const Bytes& buffer)
 {
 	size_t pos = 0;
 
@@ -11,7 +12,7 @@ void hexdump(std::ostream& stream, const std::vector<uint8_t>& buffer)
 		for (int i=0; i<16; i++)
 		{
 			if ((pos+i) < buffer.size())
-				stream << fmt::format("{:02x} ", buffer.at(pos+i));
+				stream << fmt::format("{:02x} ", buffer[pos+i]);
 			else
 				stream << "-- ";
 		}
@@ -21,7 +22,7 @@ void hexdump(std::ostream& stream, const std::vector<uint8_t>& buffer)
 			if ((pos+i) >= buffer.size())
 				break;
 
-			uint8_t c = buffer.at(pos+i);
+			uint8_t c = buffer[pos+i];
 			stream << (isprint(c) ? (char)c : '.');
 		}
 		stream << std::endl;

--- a/lib/ibm/decoder.cc
+++ b/lib/ibm/decoder.cc
@@ -50,14 +50,14 @@ SectorVector AbstractIbmDecoder::decodeToSectors(const RawRecordVector& rawRecor
                 unsigned size = 1 << (idam.sectorSize + 7);
                 data.resize(IBM_DAM_LEN + size + 2);
 
-                const Bytes payload = data.slice(IBM_DAM_LEN, size);
-				uint16_t gotCrc = crc16(CCITT_POLY, payload);
+				uint16_t gotCrc = crc16(CCITT_POLY, bytes.slice(0, IBM_DAM_LEN+size+headerSize));
 				uint16_t wantedCrc = data.reader().seek(IBM_DAM_LEN+size).read_be16();
 				int status = (gotCrc == wantedCrc) ? Sector::OK : Sector::BAD_CHECKSUM;
 
                 int sectorNum = idam.sector - _sectorIdBase;
                 auto sector = std::unique_ptr<Sector>(
-					new Sector(status, idam.cylinder, idam.side, sectorNum, payload));
+					new Sector(status, idam.cylinder, idam.side, sectorNum,
+                        data.slice(IBM_DAM_LEN, size)));
                 sectors.push_back(std::move(sector));
                 idamValid = false;
                 break;

--- a/lib/image.cc
+++ b/lib/image.cc
@@ -30,7 +30,6 @@ void readSectorsFromFile(SectorSet& sectors, const Geometry& geometry,
 					geometry.tracks * trackSize / 1024)
 			  << std::endl;
 
-	std::vector<uint8_t> data(geometry.sectorSize);
 	for (int track = 0; track < geometry.tracks; track++)
 	{
 		for (int head = 0; head < geometry.heads; head++)
@@ -38,7 +37,9 @@ void readSectorsFromFile(SectorSet& sectors, const Geometry& geometry,
 			for (int sectorId = 0; sectorId < geometry.sectors; sectorId++)
 			{
 				inputFile.seekg(track*trackSize + head*headSize + sectorId*geometry.sectorSize, std::ios::beg);
-				inputFile.read((char*) &data[0], geometry.sectorSize);
+
+				Bytes data(geometry.sectorSize);
+				inputFile.read((char*) data.begin(), geometry.sectorSize);
 
 				sectors.get(track, head, sectorId).reset(
 					new Sector(Sector::OK, track, head, sectorId, data));

--- a/lib/macintosh/decoder.cc
+++ b/lib/macintosh/decoder.cc
@@ -159,7 +159,7 @@ SectorVector MacintoshDecoder::decodeToSectors(
                 headerIsValid = false;
 
                 Bytes inputbuffer(MAC_ENCODED_SECTOR_LENGTH + 4);
-                for (unsigned i=0; i<sizeof(inputbuffer); i++)
+                for (unsigned i=0; i<inputbuffer.size(); i++)
                 {
                     auto p = rawbytes.begin() + 4 + i;
                     if (p > rawbytes.end())

--- a/lib/sector.h
+++ b/lib/sector.h
@@ -1,6 +1,8 @@
 #ifndef SECTOR_H
 #define SECTOR_H
 
+#include "bytes.h"
+
 /* 
  * Note that sectors here used zero-based numbering throughout (to make the
  * maths easier); traditionally floppy disk use 0-based track numbering and
@@ -19,7 +21,7 @@ public:
 
     static const std::string statusToString(Status status);
 
-    Sector(int status, int track, int side, int sector, const std::vector<uint8_t>& data):
+    Sector(int status, int track, int side, int sector, const Bytes& data):
 		status(status),
         track(track),
         side(side),
@@ -31,7 +33,7 @@ public:
     const int track;
     const int side;
     const int sector;
-    const std::vector<uint8_t> data;
+    const Bytes data;
 };
 
 typedef std::vector<std::unique_ptr<Sector>> SectorVector;

--- a/lib/sql.cc
+++ b/lib/sql.cc
@@ -104,7 +104,7 @@ void sqlPrepareFlux(sqlite3* db)
 
 void sqlWriteFlux(sqlite3* db, int track, int side, const Fluxmap& fluxmap)
 {
-    const auto compressed = compress(fluxmap.rawBytes());
+    const auto compressed = fluxmap.rawBytes().compress();
 
     sqlite3_stmt* stmt;
     sqlCheck(db, sqlite3_prepare_v2(db,
@@ -141,7 +141,7 @@ std::unique_ptr<Fluxmap> sqlReadFlux(sqlite3* db, int track, int side)
         const uint8_t* blobptr = (const uint8_t*) sqlite3_column_blob(stmt, 0);
         size_t bloblen = sqlite3_column_bytes(stmt, 0);
         int compression = sqlite3_column_int(stmt, 1);
-        std::vector<uint8_t> data(blobptr, blobptr+bloblen);
+        Bytes data(blobptr, bloblen);
 
         switch (compression)
         {
@@ -149,7 +149,7 @@ std::unique_ptr<Fluxmap> sqlReadFlux(sqlite3* db, int track, int side)
                 break;
 
             case COMPRESSION_ZLIB:
-                data = decompress(data);
+                data = data.decompress();
                 break;
 
             default:

--- a/meson.build
+++ b/meson.build
@@ -196,3 +196,4 @@ test('FmMfm',           executable('fmmfm-test', ['tests/fmmfm.cc'],            
 test('BitAccumulator',  executable('bitaccumulator-test', ['tests/bitaccumulator.cc'], include_directories: [feinc], link_with: [felib]))
 test('Kryoflux',        executable('kryoflux-test', ['tests/kryoflux.cc'],             include_directories: [feinc, decoderinc, streaminc], link_with: [felib, decoderlib, streamlib]))
 test('Compression',     executable('compression-test', ['tests/compression.cc'],       include_directories: [feinc, decoderinc, streaminc], link_with: [felib, decoderlib, streamlib]))
+test('Bytes',           executable('bytes-test', ['tests/bytes.cc'],                   include_directories: [feinc], link_with: [felib]))

--- a/meson.build
+++ b/meson.build
@@ -182,7 +182,7 @@ executable('fe-readvictor9k',      ['src/fe-readvictor9k.cc'],      include_dire
 executable('fe-rpm',               ['src/fe-rpm.cc'],               include_directories: [feinc], link_with: [felib])
 executable('fe-seek',              ['src/fe-seek.cc'],              include_directories: [feinc], link_with: [felib])
 executable('fe-testbulktransport', ['src/fe-testbulktransport.cc'], include_directories: [feinc], link_with: [felib])
-executable('fe-update',            ['src/fe-upgradefluxfile.cc'],   include_directories: [feinc, fmtinc], link_with: [felib, fmtlib, sqllib])
+executable('fe-upgradefluxfile',   ['src/fe-upgradefluxfile.cc'],   include_directories: [feinc, fmtinc], link_with: [felib, fmtlib, sqllib])
 executable('fe-writebrother',      ['src/fe-writebrother.cc'],      include_directories: [feinc, fmtinc, decoderinc, brotherinc], link_with: [felib, writerlib, decoderlib, encoderlib, brotherencoderlib, fmtlib])
 executable('fe-writeflux',         ['src/fe-writeflux.cc'],         include_directories: [feinc, fmtinc], link_with: [felib, readerlib, writerlib, fmtlib])
 executable('fe-writetestpattern',  ['src/fe-writetestpattern.cc'],  include_directories: [feinc, fmtinc], link_with: [felib, writerlib, fmtlib])

--- a/tests/bitaccumulator.cc
+++ b/tests/bitaccumulator.cc
@@ -4,11 +4,14 @@
 
 int main(int argc, const char* argv[])
 {
-    BitAccumulator ba;
+    Bytes bytes;
+    ByteWriter bw(bytes);
+    BitWriter bitw(bw);
 
-    ba.reset();
-    ba.push(0x1e, 5);
-    assert((std::vector<uint8_t>)ba == std::vector<uint8_t>{ 0x1e });
+    bitw.push(0x1e, 5);
+    bitw.flush();
+
+    assert(bytes == Bytes{ 0x1e });
 
     return 0;
 }

--- a/tests/bytes.cc
+++ b/tests/bytes.cc
@@ -1,0 +1,107 @@
+#include "globals.h"
+#include "bytes.h"
+
+static void check_oob(Bytes& b, unsigned pos)
+{
+    try
+    {
+        b[pos];
+    }
+    catch (const std::out_of_range& e)
+    {
+        return;
+    }
+
+    assert(false);
+}
+
+static void test_bounds()
+{
+    Bytes b1 = {1, 2, 3, 4};
+    assert(b1.size() == 4);
+    assert(b1[0] == 1);
+    assert(b1[3] == 4);
+    check_oob(b1, 4);
+
+    Bytes b2 = b1.slice(1, 2);
+    assert(b2.size() == 2);
+    assert(b2[0] == 2);
+    assert(b2[1] == 3);
+    check_oob(b2, 2);
+}
+
+static void test_loop()
+{
+    Bytes b = {1, 2, 3, 4};
+
+    std::vector<uint8_t> v(b.begin(), b.end());
+    assert((v == std::vector<uint8_t>{ 1, 2, 3, 4 }));
+
+    unsigned sum = 0;
+    for (uint8_t i : b)
+        sum += i;
+    assert(sum == 10);
+}
+
+static void test_equality()
+{
+    Bytes b1 = {1, 2, 1, 2};
+    Bytes b2 = b1.slice(0, 2);
+    Bytes b3 = b1.slice(2, 2);
+    assert(b2 == b3);
+
+    b2 = b1.slice(1, 2);
+    assert(b2 != b3);
+}
+
+static void test_reads()
+{
+    Bytes b = {1, 2, 3, 4};
+
+    b.seek(0);
+    assert(b.read_be16() == 0x0102);
+    assert(b.read_le16() == 0x0403);
+
+    b.seek(0);
+    assert(b.read_8() == 0x01);
+    assert(b.read_8() == 0x02);
+
+    b.seek(0); assert(b.read_be24() == 0x010203);
+    b.seek(0); assert(b.read_le24() == 0x030201);
+    b.seek(0); assert(b.read_be32() == 0x01020304);
+    b.seek(0); assert(b.read_le32() == 0x04030201);
+}
+
+static void test_writes()
+{
+    Bytes b;
+
+    b.seek(0);
+    b.write_8(1);
+    assert((b == Bytes{ 1 }));
+    b.write_be32(0x02020202);
+    assert((b == Bytes{ 1, 2, 2, 2, 2 }));
+
+    auto reset = [&]() { b.resize(0); b.seek(0); };
+
+    reset(); b.write_le16(0x0102); assert((b == Bytes{ 2, 1 }));
+    reset(); b.write_be16(0x0102); assert((b == Bytes{ 1, 2 }));
+    reset(); b.write_le24(0x010203); assert((b == Bytes{ 3, 2, 1 }));
+    reset(); b.write_be24(0x010203); assert((b == Bytes{ 1, 2, 3 }));
+    reset(); b.write_le32(0x01020304); assert((b == Bytes{ 4, 3, 2, 1 }));
+    reset(); b.write_be32(0x01020304); assert((b == Bytes{ 1, 2, 3, 4 }));
+
+    reset();
+    b.write({ 1, 2, 3, 4, 5 });
+    assert((b == Bytes{ 1, 2, 3, 4, 5 }));
+}
+
+int main(int argc, const char* argv[])
+{
+    test_bounds();
+    test_loop();
+    test_equality();
+    test_reads();
+    test_writes();
+    return 0;
+}

--- a/tests/bytes.cc
+++ b/tests/bytes.cc
@@ -25,7 +25,6 @@ static void test_bounds()
 
     Bytes b2 = b1.slice(1, 2);
     assert(b2.size() == 2);
-    int i = b2[0];
     assert(b2[0] == 2);
     assert(b2[1] == 3);
     check_oob(b2, 2);

--- a/tests/bytes.cc
+++ b/tests/bytes.cc
@@ -25,6 +25,7 @@ static void test_bounds()
 
     Bytes b2 = b1.slice(1, 2);
     assert(b2.size() == 2);
+    int i = b2[0];
     assert(b2[0] == 2);
     assert(b2[1] == 3);
     check_oob(b2, 2);
@@ -57,42 +58,44 @@ static void test_equality()
 static void test_reads()
 {
     Bytes b = {1, 2, 3, 4};
+    ByteReader br(b);
 
-    b.seek(0);
-    assert(b.read_be16() == 0x0102);
-    assert(b.read_le16() == 0x0403);
+    br.seek(0);
+    assert(br.read_be16() == 0x0102);
+    assert(br.read_le16() == 0x0403);
 
-    b.seek(0);
-    assert(b.read_8() == 0x01);
-    assert(b.read_8() == 0x02);
+    br.seek(0);
+    assert(br.read_8() == 0x01);
+    assert(br.read_8() == 0x02);
 
-    b.seek(0); assert(b.read_be24() == 0x010203);
-    b.seek(0); assert(b.read_le24() == 0x030201);
-    b.seek(0); assert(b.read_be32() == 0x01020304);
-    b.seek(0); assert(b.read_le32() == 0x04030201);
+    br.seek(0); assert(br.read_be24() == 0x010203);
+    br.seek(0); assert(br.read_le24() == 0x030201);
+    br.seek(0); assert(br.read_be32() == 0x01020304);
+    br.seek(0); assert(br.read_le32() == 0x04030201);
 }
 
 static void test_writes()
 {
     Bytes b;
+    ByteWriter bw(b);
 
-    b.seek(0);
-    b.write_8(1);
+    bw.seek(0);
+    bw.write_8(1);
     assert((b == Bytes{ 1 }));
-    b.write_be32(0x02020202);
+    bw.write_be32(0x02020202);
     assert((b == Bytes{ 1, 2, 2, 2, 2 }));
 
-    auto reset = [&]() { b.resize(0); b.seek(0); };
+    auto reset = [&]() { b.resize(0); bw.seek(0); };
 
-    reset(); b.write_le16(0x0102); assert((b == Bytes{ 2, 1 }));
-    reset(); b.write_be16(0x0102); assert((b == Bytes{ 1, 2 }));
-    reset(); b.write_le24(0x010203); assert((b == Bytes{ 3, 2, 1 }));
-    reset(); b.write_be24(0x010203); assert((b == Bytes{ 1, 2, 3 }));
-    reset(); b.write_le32(0x01020304); assert((b == Bytes{ 4, 3, 2, 1 }));
-    reset(); b.write_be32(0x01020304); assert((b == Bytes{ 1, 2, 3, 4 }));
+    reset(); bw.write_le16(0x0102); assert((b == Bytes{ 2, 1 }));
+    reset(); bw.write_be16(0x0102); assert((b == Bytes{ 1, 2 }));
+    reset(); bw.write_le24(0x010203); assert((b == Bytes{ 3, 2, 1 }));
+    reset(); bw.write_be24(0x010203); assert((b == Bytes{ 1, 2, 3 }));
+    reset(); bw.write_le32(0x01020304); assert((b == Bytes{ 4, 3, 2, 1 }));
+    reset(); bw.write_be32(0x01020304); assert((b == Bytes{ 1, 2, 3, 4 }));
 
     reset();
-    b.write({ 1, 2, 3, 4, 5 });
+    bw += { 1, 2, 3, 4, 5 };
     assert((b == Bytes{ 1, 2, 3, 4, 5 }));
 }
 

--- a/tests/compression.cc
+++ b/tests/compression.cc
@@ -3,11 +3,10 @@
 
 static void test_roundtrip()
 {
-    std::string sourceText = "This is some data.";
-    std::vector<uint8_t> source(sourceText.begin(), sourceText.end());
+    Bytes source = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-    auto compressed = compress(source);
-    auto decompressed = decompress(compressed);
+    auto compressed = source.compress();
+    auto decompressed = compressed.decompress();
 
     assert(decompressed == source);
 }

--- a/tests/fmmfm.cc
+++ b/tests/fmmfm.cc
@@ -15,7 +15,7 @@ int main(int argc, const char* argv[])
             true, false,
             true, false
         }
-    ) == std::vector<uint8_t>{ 0x00 });
+    ) == Bytes{ 0x00 });
 
     assert(decodeFmMfm(
         std::vector<bool>{
@@ -28,14 +28,14 @@ int main(int argc, const char* argv[])
             true, false,
             true, true
         }
-    ) == std::vector<uint8_t>{ 0x81 });
+    ) == Bytes{ 0x81 });
 
     assert(decodeFmMfm(
         std::vector<bool>{
             true, true,
             true, false,
         }
-    ) == std::vector<uint8_t>{ 0x80 });
+    ) == Bytes{ 0x80 });
 
     return 0;
 }

--- a/tests/kryoflux.cc
+++ b/tests/kryoflux.cc
@@ -5,22 +5,20 @@
 #include "fluxmap.h"
 #include "stream.h"
 
-typedef std::vector<uint8_t> bvector;
-
 struct memstreambuf : std::streambuf
 {
-    memstreambuf(const bvector& vec)
+    memstreambuf(const Bytes& bytes)
     {
-        this->setg((char*) &vec[0], (char*) &vec[0], (char*) &vec[0]+vec.size());
+        this->setg((char*) bytes.begin(), (char*) bytes.begin(), (char*) bytes.end());
     }
 };
 
 class memstream : public std::istream
 {
 public:
-    memstream(const bvector& vec):
+    memstream(const Bytes& bytes):
         std::istream(&_buffer),
-        _buffer(vec)
+        _buffer(bytes)
     {
         rdbuf(&_buffer);
     }
@@ -29,22 +27,25 @@ private:
     memstreambuf _buffer;
 };
 
-static bvector operator + (const bvector& left, const bvector& right)
+static Bytes operator + (const Bytes& left, const Bytes& right)
 {
-    bvector out = left;
-    out.insert(out.end(), right.begin(), right.end());
-    return out;
+    Bytes output;
+    ByteWriter bw(output);
+    bw += left;
+    bw += right;
+    return output;
 }
 
-static bvector operator * (const bvector& left, size_t count)
+static Bytes operator * (const Bytes& left, size_t count)
 {
-    bvector out;
+    Bytes output;
+    ByteWriter bw(output);
     while (count--)
-        out.insert(out.end(), left.begin(), left.end());
-    return out;
+        bw += left;
+    return output;
 }
 
-static void test_convert(const bvector& kryofluxbytes, const bvector& fluxmapbytes)
+static void test_convert(const Bytes& kryofluxbytes, const Bytes& fluxmapbytes)
 {
     memstream stream(kryofluxbytes);
     std::unique_ptr<Fluxmap> fluxmap = readStream(stream);
@@ -64,55 +65,55 @@ static void test_convert(const bvector& kryofluxbytes, const bvector& fluxmapbyt
 static void test_stream_reader()
 {
     test_convert(
-        bvector{},
-        bvector{}
+        Bytes{},
+        Bytes{}
     );
 
     /* Simple one-byte intervals */
     test_convert(
-        bvector{ 0x20, 0x20, 0x20, 0x20 },
-        bvector{ 0x0f, 0x0f, 0x0f, 0x0f }
+        Bytes{ 0x20, 0x20, 0x20, 0x20 },
+        Bytes{ 0x0f, 0x0f, 0x0f, 0x0f }
     );
 
     /* One-and-a-half-byte intervals */
     test_convert(
-        bvector{ 0x20, 0x00, 0x10, 0x20, 0x01, 0x10, 0x20 },
-        bvector{ 0x0f, 0x07, 0x0f, 0x80, 0x07, 0x0f }
+        Bytes{ 0x20, 0x00, 0x10, 0x20, 0x01, 0x10, 0x20 },
+        Bytes{ 0x0f, 0x07, 0x0f, 0x80, 0x07, 0x0f }
     );
 
     /* Two-byte intervals */
     test_convert(
-        bvector{ 0x20, 0x0c, 0x00, 0x10, 0x20, 0x0c, 0x01, 0x10, 0x20 },
-        bvector{ 0x0f, 0x07, 0x0f, 0x80, 0x07, 0x0f }
+        Bytes{ 0x20, 0x0c, 0x00, 0x10, 0x20, 0x0c, 0x01, 0x10, 0x20 },
+        Bytes{ 0x0f, 0x07, 0x0f, 0x80, 0x07, 0x0f }
     );
 
     /* Overflow */
     test_convert(
-        bvector{ 0x20, 0x0b, 0x10, 0x20 },
-        bvector{ 0x0f } + (bvector{ 0x80 } * 0xff) + bvector{ 0x62, 0x0f }
+        Bytes{ 0x20, 0x0b, 0x10, 0x20 },
+        Bytes{ 0x0f } + (Bytes{ 0x80 } * 0xff) + Bytes{ 0x62, 0x0f }
     );
 
     /* Single-byte nop */
     test_convert(
-        bvector{ 0x20, 0x08, 0x20 },
-        bvector{ 0x0f, 0x0f }
+        Bytes{ 0x20, 0x08, 0x20 },
+        Bytes{ 0x0f, 0x0f }
     );
 
     /* Double-byte nop */
     test_convert(
-        bvector{ 0x20, 0x09, 0xde, 0x20 },
-        bvector{ 0x0f, 0x0f }
+        Bytes{ 0x20, 0x09, 0xde, 0x20 },
+        Bytes{ 0x0f, 0x0f }
     );
 
     /* Triple-byte nop */
     test_convert(
-        bvector{ 0x20, 0x0a, 0xde, 0xad, 0x20 },
-        bvector{ 0x0f, 0x0f }
+        Bytes{ 0x20, 0x0a, 0xde, 0xad, 0x20 },
+        Bytes{ 0x0f, 0x0f }
     );
 
     /* OOB block */
     test_convert(
-        bvector{
+        Bytes{
             0x20, /* data before */
             0x0d, /* OOB */
             0xaa, /* type byte */
@@ -120,7 +121,7 @@ static void test_stream_reader()
             0x55, /* payload */
             0x20 /* data continues */
         },
-        bvector{ 0x0f, 0x0f }
+        Bytes{ 0x0f, 0x0f }
     );
 }
 

--- a/tools/cwftoflux.cc
+++ b/tools/cwftoflux.cc
@@ -77,7 +77,7 @@ static void read_track()
     inputFile.read((char*) &trackheader, sizeof(trackheader));
     check_for_error();
 
-    uint32_t length = read_le32(trackheader.length) - sizeof(CwfTrack);
+    uint32_t length = Bytes(trackheader.length, 4).reader().read_le32() - sizeof(CwfTrack);
     unsigned track_number = trackheader.track * header.step;
     std::cout << fmt::format("{}.{}: {} input bytes; ", track_number, trackheader.side, length)
         << std::flush;


### PR DESCRIPTION
This is a massive reworking of how bytes are handled: instead of doing everything with copying of std::vector<uint8_t>, we now have a Bytes class with Java-style ByteReader/ByteWriter/BitWriter helper classes that go with it. Backing buffers are shared whenever possible. Slicing a Bytes to a subset is cheap so we can pass around iterable slices rather than horrible C++ iterators. Bounds checking happens more.