### PR TITLE
Add the ability for decoders to specify their own clocks.

### DIFF
--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -47,9 +47,6 @@ static const std::string BLOCK_ELEMENTS[] =
  */
 nanoseconds_t Fluxmap::guessClock() const
 {
-	if (manualClockRate != 0.0)
-		return manualClockRate * 1000.0;
-
     uint32_t buckets[256] = {};
     size_t cursor = 0;
     FluxmapReader fr(*this);
@@ -203,7 +200,14 @@ abort:
     return rawbits;
 }
 
-nanoseconds_t AbstractDecoder::guessClock(Fluxmap& fluxmap) const
+nanoseconds_t AbstractDecoder::guessClock(Fluxmap& fluxmap, unsigned physicalTrack) const
+{
+	if (manualClockRate != 0.0)
+		return manualClockRate * 1000.0;
+    return guessClockImpl(fluxmap, physicalTrack);
+}
+
+nanoseconds_t AbstractDecoder::guessClockImpl(Fluxmap& fluxmap, unsigned) const
 {
     return fluxmap.guessClock();
 }

--- a/lib/decoders/decoders.h
+++ b/lib/decoders/decoders.h
@@ -24,7 +24,8 @@ class AbstractDecoder
 public:
     virtual ~AbstractDecoder() {}
 
-    virtual nanoseconds_t guessClock(Fluxmap& fluxmap) const;
+    nanoseconds_t guessClock(Fluxmap& fluxmap, unsigned physicalTrack) const;
+    virtual nanoseconds_t guessClockImpl(Fluxmap& fluxmap, unsigned physicalTrack) const;
 
     virtual void decodeToSectors(const RawBits& bitmap, unsigned physicalTrack,
         RawRecordVector& rawrecords, SectorVector& sectors) = 0;

--- a/lib/reader.cc
+++ b/lib/reader.cc
@@ -146,7 +146,7 @@ void readDiskCommand(AbstractDecoder& decoder, const std::string& outputFilename
 		{
 			std::unique_ptr<Fluxmap> fluxmap = track->read();
 
-			nanoseconds_t clockPeriod = decoder.guessClock(*fluxmap);
+			nanoseconds_t clockPeriod = decoder.guessClock(*fluxmap, track->track);
 			if (clockPeriod == 0)
 			{
 				std::cout << "       no clock detected; giving up" << std::endl;

--- a/lib/victor9k/decoder.cc
+++ b/lib/victor9k/decoder.cc
@@ -119,3 +119,26 @@ int Victor9kDecoder::recordMatcher(uint64_t fifo) const
 		return 9;
     return 0;
 }
+
+nanoseconds_t Victor9kDecoder::guessClockImpl(Fluxmap& fluxmap, unsigned physicalTrack) const
+{
+    const nanoseconds_t BASE_CLOCK = 2065;
+    const double BASE_SPEED = 167.0;
+
+    if (physicalTrack < 4)
+        return BASE_CLOCK * BASE_SPEED / 237.9;
+    else if (physicalTrack < 16)
+        return BASE_CLOCK * BASE_SPEED / 224.5;
+    else if (physicalTrack < 27)
+        return BASE_CLOCK * BASE_SPEED / 212.2;
+    else if (physicalTrack < 38)
+        return BASE_CLOCK * BASE_SPEED / 199.9;
+    else if (physicalTrack < 49)
+        return BASE_CLOCK * BASE_SPEED / 187.6;
+    else if (physicalTrack < 60)
+        return BASE_CLOCK * BASE_SPEED / 175.3;
+    else if (physicalTrack < 71)    
+        return BASE_CLOCK * BASE_SPEED / 163.0;
+    else
+        return BASE_CLOCK * BASE_SPEED / 149.6;
+}

--- a/lib/victor9k/victor9k.h
+++ b/lib/victor9k/victor9k.h
@@ -17,6 +17,8 @@ public:
     SectorVector decodeToSectors(
         const RawRecordVector& rawRecords, unsigned physicalTrack);
     int recordMatcher(uint64_t fifo) const;
+
+    nanoseconds_t guessClockImpl(Fluxmap& fluxmap, unsigned physicalTrack) const;
 };
 
 #endif


### PR DESCRIPTION
This is necessary for the Victor 9k; we now have _much_ better decoding for this platform.