### PR TITLE
Fix memory corruption issue when replacing sectors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
         - libsqlite3-dev
         - g++-8
     homebrew:
+        update: true
         packages:
         - ninja
         - meson

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
             env: CXX=g++-8
         -
             os: osx
-            env: HOMEBREW_NO_AUTO_UPDATE=1
             compiler: clang
 
 addons:

--- a/lib/image.cc
+++ b/lib/image.cc
@@ -41,7 +41,8 @@ void readSectorsFromFile(SectorSet& sectors, const Geometry& geometry,
 				Bytes data(geometry.sectorSize);
 				inputFile.read((char*) data.begin(), geometry.sectorSize);
 
-				Sector* sector = sectors.get(track, head, sectorId) = new Sector();
+				std::unique_ptr<Sector>& sector = sectors.get(track, head, sectorId);
+				sector.reset(new Sector);
 				sector->status = Sector::OK;
 				sector->logicalTrack = sector->physicalTrack = track;
 				sector->logicalSide = sector->physicalSide = head;

--- a/lib/sectorset.cc
+++ b/lib/sectorset.cc
@@ -3,7 +3,7 @@
 #include "sector.h"
 #include "sectorset.h"
 
-Sector*& SectorSet::get(int track, int head, int sector)
+std::unique_ptr<Sector>& SectorSet::get(int track, int head, int sector)
 {
 	key_t key(track, head, sector);
 	return _data[key];
@@ -11,11 +11,11 @@ Sector*& SectorSet::get(int track, int head, int sector)
 
 Sector* SectorSet::get(int track, int head, int sector) const
 {
-        key_t key(track, head, sector);
+    key_t key(track, head, sector);
 	auto i = _data.find(key);
 	if (i == _data.end())
 		return NULL;
-	return i->second;
+	return i->second.get();
 }
 
 void SectorSet::calculateSize(int& numTracks, int& numHeads, int& numSectors,

--- a/lib/sectorset.h
+++ b/lib/sectorset.h
@@ -14,14 +14,14 @@ public:
 
 	SectorSet() {};
 
-	Sector*& get(int track, int head, int sector);
+	std::unique_ptr<Sector>& get(int track, int head, int sector);
 	Sector* get(int track, int head, int sector) const;
 
 	void calculateSize(int& numTracks, int& numHeads, int& numSectors,
 		int& sectorSize) const;
 
 private:
-	std::map<const key_t, Sector*> _data;
+	std::map<const key_t, std::unique_ptr<Sector>> _data;
 };
 
 #endif


### PR DESCRIPTION
This fixes a nasty memory corruption issue in replace_sector where if a sector got reread it would sometimes be freed in memory before we'd finished using it --- yes, another C++ object lifecycle issue. 
Weirdly this worked fine on Linux but would crash Cygwin.

Fixes: #66 