### PR TITLE
Use mingw32 to build the Windows client, removing the cygwin dependency.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,10 +1,15 @@
+version: '{branch}.{build}'
+clone_depth: 1
+
 environment:
   MSYSTEM: MINGW32
-
-clone_depth: 1
+  PATH: c:\msys64\mingw32\bin
 
 init:
   - git config --global core.autocrlf input
+
+install:
+  - pacman -S make ninja mingw-w64-i686-libusb  mingw-w64-i686-sqlite3 mingw-w64-i686-zlib 
 
 build_script:
   - make

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,8 @@ init:
   - git config --global core.autocrlf input
 
 install:
-  - set PATH=%PATH%;c:\msys64\mingw32\bin;c:\msys64\usr\bin;c:\msys64\bin
+  - set c:\msys64\mingw32\bin;c:\msys64\usr\bin;c:\msys64\bin;%PATH%
+  - echo %PATH%
   - pacman -S --noconfirm make ninja mingw-w64-i686-libusb mingw-w64-i686-sqlite3 mingw-w64-i686-zlib 
 
 build_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ init:
 install:
   - set PATH=c:\msys64\mingw32\bin;c:\msys64\usr\bin;c:\msys64\bin;%PATH%
   - echo %PATH%
-  - pacman -S --noconfirm make ninja mingw-w64-i686-libusb mingw-w64-i686-sqlite3 mingw-w64-i686-zlib 
+  - pacman -S --noconfirm --needed make ninja mingw-w64-i686-libusb mingw-w64-i686-sqlite3 mingw-w64-i686-zlib mingw-w64-i686-gcc
 
 build_script:
   - make

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ init:
   - git config --global core.autocrlf input
 
 install:
-  - set PATH=%PATH%;c:\msys64\mingw32\bin
+  - set PATH=%PATH%;c:\msys64\mingw32\bin;c:\msys64\usr\bin;c:\msys64\bin
   - pacman -S make ninja mingw-w64-i686-libusb  mingw-w64-i686-sqlite3 mingw-w64-i686-zlib 
 
 build_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ init:
 
 install:
   - set PATH=%PATH%;c:\msys64\mingw32\bin;c:\msys64\usr\bin;c:\msys64\bin
-  - pacman -S make ninja mingw-w64-i686-libusb  mingw-w64-i686-sqlite3 mingw-w64-i686-zlib 
+  - pacman -S --noconfirm make ninja mingw-w64-i686-libusb mingw-w64-i686-sqlite3 mingw-w64-i686-zlib 
 
 build_script:
   - make

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,12 +3,12 @@ clone_depth: 1
 
 environment:
   MSYSTEM: MINGW32
-  PATH: c:\msys64\mingw32\bin
 
 init:
   - git config --global core.autocrlf input
 
 install:
+  - set PATH=%PATH%;c:\msys64\mingw32\bin
   - pacman -S make ninja mingw-w64-i686-libusb  mingw-w64-i686-sqlite3 mingw-w64-i686-zlib 
 
 build_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,19 +1,13 @@
 environment:
-  matrix:
-  - CYGWIN: C:\cygwin64
+  MSYSTEM: MINGW32
 
 clone_depth: 1
 
 init:
   - git config --global core.autocrlf input
 
-install:
-  - '%CYGWIN%\bin\bash -lc "cygcheck -dc cygwin"'
-  - '%CYGWIN%\setup-x86_64 -q -P libsqlite3-devel,ninja,zlib-devel,libusb1.0-devel'
-
 build_script:
-  - 'echo building...'
-  - '%CYGWIN%\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; exec 0</dev/null; make"'
+  - make
 
 artifacts:
   - path: fluxengine.exe

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ init:
   - git config --global core.autocrlf input
 
 install:
-  - set c:\msys64\mingw32\bin;c:\msys64\usr\bin;c:\msys64\bin;%PATH%
+  - set PATH=c:\msys64\mingw32\bin;c:\msys64\usr\bin;c:\msys64\bin;%PATH%
   - echo %PATH%
   - pacman -S --noconfirm make ninja mingw-w64-i686-libusb mingw-w64-i686-sqlite3 mingw-w64-i686-zlib 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: shell
+git:
+    depth: 1
 
 matrix:
     include:
@@ -8,16 +10,22 @@ matrix:
             dist: xenial
             compiler: gcc
             env: CXX=g++-8
+            script:
+              - make
         -
             os: osx
             osx_image: xcode10.2
             compiler: clang
+            script:
+              - make
         -
             os: windows
-
+            env:
+              MSYSTEM: MINGW32
             install:
-            - choco upgrade git.install
-            - pacman -S ninja
+            - choco install ninja
+            script:
+              - c:/msys64/usr/bin/make
 
 addons:
     apt:
@@ -33,9 +41,4 @@ addons:
         packages:
         - ninja
 
-git:
-    depth: 1
-
-script:
-    - make
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,6 @@ matrix:
             os: osx
             osx_image: xcode10.2
             compiler: clang
-            script:
-              - make
-        -
-            os: windows
-            env:
-              MSYSTEM: MINGW32
-            install:
-            - choco install msys2 --params /noupdate
-            - c:/tools/msys64/usr/bin/pacman -S ninja
-            script:
-              - c:/tools/msys64/usr/bin/make
 
 addons:
     apt:
@@ -41,5 +30,8 @@ addons:
     homebrew:
         packages:
         - ninja
+
+script:
+- make
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: generic
+language: shell
 
 matrix:
     include:
@@ -14,6 +14,7 @@ matrix:
             compiler: clang
         -
             os: windows
+
             install:
             - choco install ninja
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: generic
+language: cpp
 
 matrix:
     include:
@@ -12,6 +12,8 @@ matrix:
             os: osx
             osx_image: xcode10.2
             compiler: clang
+        -
+            os: windows
 
 addons:
     apt:
@@ -24,6 +26,9 @@ addons:
         - libsqlite3-dev
         - g++-8
     homebrew:
+        packages:
+        - ninja
+    chocolatey:
         packages:
         - ninja
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
             os: windows
 
             install:
-            - choco install ninja
+            - pacman -S ninja
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
             os: windows
 
             install:
+            - choco upgrade git.install
             - pacman -S ninja
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,9 @@ matrix:
               MSYSTEM: MINGW32
             install:
             - choco install msys2
+            - c:/tools/msys64/usr/bin/pacman -S ninja
             script:
-              - c:/msys64/usr/bin/make
+              - c:/tools/msys64/usr/bin/make
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
             env:
               MSYSTEM: MINGW32
             install:
-            - choco install msys2
+            - choco install msys2 /noupdate
             - c:/tools/msys64/usr/bin/pacman -S ninja
             script:
               - c:/tools/msys64/usr/bin/make

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
             env:
               MSYSTEM: MINGW32
             install:
-            - choco install msys2 /noupdate
+            - choco install msys2 --params /noupdate
             - c:/tools/msys64/usr/bin/pacman -S ninja
             script:
               - c:/tools/msys64/usr/bin/make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: cpp
+language: generic
 
 matrix:
     include:
@@ -14,6 +14,8 @@ matrix:
             compiler: clang
         -
             os: windows
+            install:
+            - choco install ninja
 
 addons:
     apt:
@@ -26,9 +28,6 @@ addons:
         - libsqlite3-dev
         - g++-8
     homebrew:
-        packages:
-        - ninja
-    chocolatey:
         packages:
         - ninja
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
             env:
               MSYSTEM: MINGW32
             install:
-            - choco install ninja
+            - choco install msys2
             script:
               - c:/msys64/usr/bin/make
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,27 @@
+PACKAGES = zlib slite3 libusb-1.0
+
+ifeq ($(OS), Windows_NT)
+export CXX = i686-w64-mingw32-g++
+export AR = i686-w64-mingw32-ar rcs
+export STRIP = i686-w64-mingw32-strip
+export CFLAGS = -Og -g --std=c++14 -I/usr/i686-w64-mingw32/sys-root/mingw/include/libusb-1.0
+export LDFLAGS = -Og
+export LIBS = -static -lz -lsqlite3 -Wl,-Bdynamic -lusb-1.0
+else
 export CXX = g++
 export AR = ar rcs
 export STRIP = strip
-export CFLAGS = -Og -g --std=c++14
+export CFLAGS = -Og -g --std=c++14 $(pkg-config --cflags $(PACKAGES))
 export LDFLAGS = -Og
+export LIBS = $(pkg-config --libs $(PACKAGES))
+endif
+
+CFLAGS += -Ilib -Idep/fmt
 
 export OBJDIR = .obj
 
 all: .obj/build.ninja
-	@ninja -f .obj/build.ninja
+	@ninja -f .obj/build.ninja -v
 
 clean:
 	@echo CLEAN

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 PACKAGES = zlib slite3 libusb-1.0
 
 ifeq ($(OS), Windows_NT)
-export CXX = i686-w64-mingw32-g++
-export AR = i686-w64-mingw32-ar rcs
-export STRIP = i686-w64-mingw32-strip
-export CFLAGS = -Og -g --std=c++14 -I/usr/i686-w64-mingw32/sys-root/mingw/include/libusb-1.0
+export CXX = /mingw32/bin/g++
+export AR = /mingw32/bin/ar rcs
+export STRIP = /mingw32/bin/strip
+export CFLAGS = -Og -g --std=c++14 -I/mingw32/include/libusb-1.0
 export LDFLAGS = -Og
-export LIBS = -static -lz -lsqlite3 -Wl,-Bdynamic -lusb-1.0
+export LIBS = -static -lz -lsqlite3 -lusb-1.0
+export EXTENSION = .exe
 else
 export CXX = g++
 export AR = ar rcs
@@ -14,6 +15,7 @@ export STRIP = strip
 export CFLAGS = -Og -g --std=c++14 $(pkg-config --cflags $(PACKAGES))
 export LDFLAGS = -Og
 export LIBS = $(pkg-config --libs $(PACKAGES))
+export EXTENSION =
 endif
 
 CFLAGS += -Ilib -Idep/fmt
@@ -27,7 +29,7 @@ clean:
 	@echo CLEAN
 	@rm -rf $(OBJDIR)
 
-.obj/build.ninja: mkninja.sh
+.obj/build.ninja: mkninja.sh Makefile
 	@echo MKNINJA $@
 	@mkdir -p $(OBJDIR)
 	@sh $< > $@

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ ifeq ($(OS), Windows_NT)
 export CXX = /mingw32/bin/g++
 export AR = /mingw32/bin/ar rcs
 export STRIP = /mingw32/bin/strip
-export CFLAGS = -Og -g --std=c++14 -I/mingw32/include/libusb-1.0
-export LDFLAGS = -Og
+export CFLAGS = -O3 -g --std=c++14 -I/mingw32/include/libusb-1.0
+export LDFLAGS = -O3
 export LIBS = -static -lz -lsqlite3 -lusb-1.0
 export EXTENSION = .exe
 else

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGES = zlib slite3 libusb-1.0
+PACKAGES = zlib sqlite3 libusb-1.0
 
 ifeq ($(OS), Windows_NT)
 export CXX = /mingw32/bin/g++
@@ -12,9 +12,9 @@ else
 export CXX = g++
 export AR = ar rcs
 export STRIP = strip
-export CFLAGS = -Og -g --std=c++14 $(pkg-config --cflags $(PACKAGES))
+export CFLAGS = -Og -g --std=c++14 $(shell pkg-config --cflags $(PACKAGES))
 export LDFLAGS = -Og
-export LIBS = $(pkg-config --libs $(PACKAGES))
+export LIBS = $(shell pkg-config --libs $(PACKAGES))
 export EXTENSION =
 endif
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -141,11 +141,22 @@ the port and proceed normally.
 
 The client software is where the intelligence, such as it is, is. It's pretty
 generic libusb stuff and should build and run on Windows, Linux and OSX as
-well, although on Windows I've only ever used it with Cygwin. You'll need the
-`sqlite3`, `libusb-1.0` and `ninja` packages (which should be easy to come by
-in your distribution). Just do `make` and it should build. The result will
-be a single executable, `fluxengine`, in the current directory. It has
-minimal dependencies and can be installed anywhere.
+well, although on Windows it'll need MSYS2 and mingw32. You'll need to
+install some support packages.
+
+  - For Linux (this is Ubuntu, but this should apply to Debian too):
+  `ninja-build`, `libusb-1.0-0-dev`, `libsqlite3-dev`.
+  - For OSX with Homebrew: `ninja`.
+  - For Windows with MSYS2: `make`, `ninja`, `mingw-w64-i686-libusb`,
+  `mingw-w64-i686-sqlite3`, `mingw-w64-i686-zlib`, `mingw-w64-i686-gcc`.
+
+These lists are not necessarily exhaustive --- plaese [get in
+touch](https://github.com/davidgiven/fluxengine/issues/new) if I've missed
+anything.
+
+All systems build by just doing `make`. You should end up with a single
+executable in the current directory, called `fluxengine`. It has minimal
+dependencies and you should be able to put it anywhere.
 
 If it doesn't build, please [get in
 touch](https://github.com/davidgiven/fluxengine/issues/new).

--- a/mkninja.sh
+++ b/mkninja.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 set -e
-packages="zlib sqlite3 libusb-1.0"
-pkgcflags="$(pkg-config --cflags $packages) -Idep/fmt"
-pkgldflags=$(pkg-config --libs $packages)
 
 cat <<EOF
 rule cxx
@@ -16,7 +13,7 @@ rule library
     description = AR \$in
 
 rule link
-    command = $CXX $LDFLAGS -o \$out \$in \$flags
+    command = $CXX $LDFLAGS -o \$out \$in \$flags $LIBS
     description = LINK \$in
 
 rule test
@@ -96,12 +93,9 @@ runtest() {
     shift
 
     buildlibrary lib$prog.a \
-        -Ilib \
-        $pkgcflags \
         "$@"
 
     buildprogram $OBJDIR/$prog \
-        $pkgldflags \
         lib$prog.a \
         libbackend.a \
         libfmt.a
@@ -114,8 +108,6 @@ buildlibrary libfmt.a \
     dep/fmt/posix.cc \
 
 buildlibrary libbackend.a \
-    -Ilib \
-    $pkgcflags \
     lib/aeslanier/decoder.cc \
     lib/amiga/decoder.cc \
     lib/apple2/decoder.cc \
@@ -158,8 +150,6 @@ buildlibrary libbackend.a \
     lib/zilogmcz/decoder.cc \
 
 buildlibrary libfrontend.a \
-    -Ilib \
-    $pkgcflags \
     src/fe-erase.cc \
     src/fe-inspect.cc \
     src/fe-readadfs.cc \
@@ -187,7 +177,6 @@ buildlibrary libfrontend.a \
     src/fluxengine.cc \
 
 buildprogram fluxengine-debug \
-    $pkgldflags \
     libfrontend.a \
     libbackend.a \
     libfmt.a \

--- a/mkninja.sh
+++ b/mkninja.sh
@@ -95,12 +95,12 @@ runtest() {
     buildlibrary lib$prog.a \
         "$@"
 
-    buildprogram $OBJDIR/$prog \
+    buildprogram $OBJDIR/$prog$EXTENSION \
         lib$prog.a \
         libbackend.a \
         libfmt.a
 
-    echo build $OBJDIR/$prog.stamp : test $OBJDIR/$prog
+    echo build $OBJDIR/$prog.stamp : test $OBJDIR/$prog$EXTENSION
 }
 
 buildlibrary libfmt.a \
@@ -176,12 +176,12 @@ buildlibrary libfrontend.a \
     src/fe-writetestpattern.cc \
     src/fluxengine.cc \
 
-buildprogram fluxengine-debug \
+buildprogram fluxengine-debug$EXTENSION \
     libfrontend.a \
     libbackend.a \
     libfmt.a \
 
-echo "build fluxengine : strip fluxengine-debug"
+echo "build fluxengine$EXTENSION : strip fluxengine-debug$EXTENSION"
 
 runtest dataspec-test       tests/dataspec.cc
 runtest flags-test          tests/flags.cc


### PR DESCRIPTION
The Windows client now builds via appveyor, and is a stock Windows binary rather than the Cygwin thing previously.