### PR TITLE
CFLAGS exported all through

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ export LIBS = $(shell pkg-config --libs $(PACKAGES))
 export EXTENSION =
 endif
 
-CFLAGS += -Ilib -Idep/fmt -Iarch
+export CFLAGS += -Ilib -Idep/fmt -Iarch
 
 export OBJDIR = .obj
 


### PR DESCRIPTION
Fixing make on Ubuntu 18.04 amd64 as it could not find libusb.h.