### PR TITLE
Validate image extensions before reading, not after.

### DIFF
--- a/lib/globals.h
+++ b/lib/globals.h
@@ -22,7 +22,7 @@ extern void hexdumpForSrp16(std::ostream& stream, const Bytes& bytes);
 class Error
 {
 public:
-    ~Error()
+    [[ noreturn ]] ~Error()
     {
         std::cerr << "Error: " << _stream.str() << std::endl;
         exit(1);

--- a/lib/imagereader/imagereader.cc
+++ b/lib/imagereader/imagereader.cc
@@ -7,6 +7,13 @@
 #include "imagereader/imagereader.h"
 #include "fmt/format.h"
 
+std::map<std::string, ImageReader::Constructor> ImageReader::formats =
+{
+	{".adf", ImageReader::createImgImageReader},
+	{".d81", ImageReader::createImgImageReader},
+	{".img", ImageReader::createImgImageReader},
+};
+
 static bool ends_with(const std::string& value, const std::string& ending)
 {
     if (ending.size() > value.size())
@@ -14,15 +21,29 @@ static bool ends_with(const std::string& value, const std::string& ending)
     return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
 }
 
-std::unique_ptr<ImageReader> ImageReader::create(const ImageSpec& spec)
+ImageReader::Constructor ImageReader::findConstructor(const ImageSpec& spec)
 {
     const auto& filename = spec.filename;
 
-    if (ends_with(filename, ".img") || ends_with(filename, ".adf"))
-        return createImgImageReader(spec);
+	for (const auto& e : formats)
+	{
+		if (ends_with(filename, e.first))
+			return e.second;
+	}
 
-    Error() << "unrecognised image filename extension";
-    return std::unique_ptr<ImageReader>();
+	return NULL;
+}
+
+std::unique_ptr<ImageReader> ImageReader::create(const ImageSpec& spec)
+{
+    verifyImageSpec(spec);
+    return findConstructor(spec)(spec);
+}
+
+void ImageReader::verifyImageSpec(const ImageSpec& spec)
+{
+    if (!findConstructor(spec))
+        Error() << "unrecognised image filename extension";
 }
 
 ImageReader::ImageReader(const ImageSpec& spec):

--- a/lib/imagereader/imagereader.h
+++ b/lib/imagereader/imagereader.h
@@ -12,9 +12,20 @@ public:
 
 public:
     static std::unique_ptr<ImageReader> create(const ImageSpec& spec);
+	static void verifyImageSpec(const ImageSpec& spec);
 
 private:
+	typedef 
+		std::function<
+			std::unique_ptr<ImageReader>(const ImageSpec& spec)
+		>
+		Constructor;
+
+	static std::map<std::string, Constructor> formats;
+
     static std::unique_ptr<ImageReader> createImgImageReader(const ImageSpec& spec);
+
+	static Constructor findConstructor(const ImageSpec& spec);
 
 public:
 	virtual SectorSet readImage() = 0;

--- a/lib/imagewriter/imagewriter.h
+++ b/lib/imagewriter/imagewriter.h
@@ -12,14 +12,25 @@ public:
 
 public:
     static std::unique_ptr<ImageWriter> create(const SectorSet& sectors, const ImageSpec& spec);
+	static void verifyImageSpec(const ImageSpec& filename);
 
 private:
+	typedef 
+		std::function<
+			std::unique_ptr<ImageWriter>(const SectorSet& sectors, const ImageSpec& spec)
+		>
+		Constructor;
+
+	static std::map<std::string, Constructor> formats;
+
     static std::unique_ptr<ImageWriter> createImgImageWriter(
 		const SectorSet& sectors, const ImageSpec& spec);
     static std::unique_ptr<ImageWriter> createLDBSImageWriter(
 		const SectorSet& sectors, const ImageSpec& spec);
     static std::unique_ptr<ImageWriter> createD64ImageWriter(
 		const SectorSet& sectors, const ImageSpec& spec);
+
+	static Constructor findConstructor(const ImageSpec& spec);
 
 public:
 	virtual void adjustGeometry();

--- a/lib/reader.cc
+++ b/lib/reader.cc
@@ -14,6 +14,7 @@
 #include "bytes.h"
 #include "decoders/rawbits.h"
 #include "track.h"
+#include "imagewriter/imagewriter.h"
 #include "fmt/format.h"
 
 FlagGroup readerFlags { &hardwareFluxSourceFlags, &fluxmapReaderFlags };
@@ -153,7 +154,8 @@ static void replace_sector(std::unique_ptr<Sector>& replacing, Sector& replaceme
 void readDiskCommand(AbstractDecoder& decoder)
 {
 	const ImageSpec outputSpec(output);
-
+	ImageWriter::verifyImageSpec(outputSpec);
+        
 	bool failures = false;
 	SectorSet allSectors;
 	auto tracks = readTracks();


### PR DESCRIPTION
Also refactor the way image formats are handled to make it generally cleaner (could be cleaner sitll, though).

Fixes: #96