### PR TITLE
Fix an issue where HD IBM disks can't be read

### DIFF
--- a/arch/ibm/decoder.cc
+++ b/arch/ibm/decoder.cc
@@ -73,8 +73,10 @@ const FluxPattern FM_TRS80DAM2_PATTERN(16, 0xf56c);
  * encoding (you can't do 10 00). So this can't be spoofed by user data.
  * 
  * shifted: 10 00 10 01 00 01 00 1
+ * 
+ * It's repeated three times.
  */
-const FluxPattern MFM_PATTERN(16, 0x4489);
+const FluxPattern MFM_PATTERN(48, 0x448944894489LL);
 
 const FluxMatchers ANY_RECORD_PATTERN(
     {

--- a/arch/ibm/decoder.cc
+++ b/arch/ibm/decoder.cc
@@ -100,7 +100,8 @@ AbstractDecoder::RecordType IbmDecoder::advanceToNextRecord()
     if (_currentHeaderLength > 0)
         readRawBits(_currentHeaderLength*16);
     auto idbits = readRawBits(16);
-    uint8_t id = decodeFmMfm(idbits).slice(0, 1)[0];
+    const Bytes idbytes = decodeFmMfm(idbits);
+    uint8_t id = idbytes.slice(0, 1)[0];
     seek(here);
     
     switch (id)

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -52,13 +52,11 @@ void AbstractDecoder::decodeToSectors(Track& track)
             sector.headerStartTime = recordStart.ns();
             sector.headerEndTime = recordEnd.ns();
             r = advanceToNextRecord();
+            recordStart = fmr.tell();
             if (r == DATA_RECORD)
-            {
-                recordStart = fmr.tell();
                 decodeDataRecord();
-                recordEnd = fmr.tell();
-                pushRecord(recordStart, recordEnd);
-            }
+            recordEnd = fmr.tell();
+            pushRecord(recordStart, recordEnd);
         }
         sector.dataStartTime = recordStart.ns();
         sector.dataEndTime = recordEnd.ns();

--- a/lib/decoders/fluxmapreader.cc
+++ b/lib/decoders/fluxmapreader.cc
@@ -25,6 +25,11 @@ static DoubleFlag clockIntervalBias(
     "Adjust intervals between pulses by this many clocks before decoding.",
     -0.02);
 
+static DoubleFlag minimumClockUs(
+    { "--minimum-clock-us" },
+    "Refuse to detect clocks shorter than this, to avoid false positives.",
+    0.75);
+
 int FluxmapReader::readOpcode(unsigned& ticks)
 {
     ticks = 0;
@@ -222,7 +227,9 @@ nanoseconds_t FluxmapReader::seekToPattern(const FluxMatcher& pattern, const Flu
             seek(positions[intervalCount-match.intervals]);
             _pos.zeroes = match.zeroes;
             matching = match.matcher;
-            return match.clock * NS_PER_TICK;
+            nanoseconds_t detectedClock = match.clock * NS_PER_TICK;
+            if (detectedClock > (minimumClockUs*1000))
+                return match.clock * NS_PER_TICK;
         }
 
         for (unsigned i=0; i<intervalCount; i++)

--- a/lib/reader.cc
+++ b/lib/reader.cc
@@ -227,8 +227,8 @@ void readDiskCommand(AbstractDecoder& decoder)
 			std::cout << "\nRaw (undecoded) records follow:\n\n";
 			for (auto& record : track->rawrecords)
 			{
-				std::cout << fmt::format("I+{:.2f}us", record.position.ns() / 1000.0)
-						<< std::endl;
+				std::cout << fmt::format("I+{:.2f}us with {:.2f}us clock\n",
+                            record.position.ns() / 1000.0, record.clock / 1000.0);
 				hexdump(std::cout, record.data);
 				std::cout << std::endl;
 			}


### PR DESCRIPTION
This is a _workaround_ to an issue with the new sampler where it appears to introduce a bit of noise to the pulse lengths. Sometimes this noise can spoof MFM marker bytes in the sync sequence before a record, causing the record's clock to be misdetected (and therefore discarded).

This fix just increases the length of the detection sequence. It doesn't get rid of the noise, which we should really look into, but it does make HD disks read again.