### PR TITLE
Fix stray bytes at the end of images

### DIFF
--- a/lib/bytes.cc
+++ b/lib/bytes.cc
@@ -258,6 +258,11 @@ void Bytes::writeToFile(const std::string& filename) const
     f.close();
 }
 
+void Bytes::writeTo(std::ostream& stream) const
+{
+	stream.write((const char*) cbegin(), size());
+}
+
 ByteReader Bytes::reader() const
 {
     return ByteReader(*this);

--- a/lib/bytes.h
+++ b/lib/bytes.h
@@ -57,6 +57,7 @@ public:
     ByteWriter writer();
 
     void writeToFile(const std::string& filename) const;
+	void writeTo(std::ostream& stream) const;
 
 private:
     std::shared_ptr<std::vector<uint8_t>> _data;

--- a/lib/imagewriter/imgimagewriter.cc
+++ b/lib/imagewriter/imgimagewriter.cc
@@ -46,7 +46,7 @@ public:
 					if (sector)
 					{
 						outputFile.seekp(sector->logicalTrack*trackSize + sector->logicalSide*headSize + sector->logicalSector*numBytes, std::ios::beg);
-						outputFile.write((const char*) sector->data.cbegin(), sector->data.size());
+						sector->data.slice(0, numBytes).writeTo(outputFile);
 					}
 				}
 			}


### PR DESCRIPTION
When writing images, use the sector size in the spec rather than the actual data size, to avoid problems with multipart formats like the Amiga.

Fixes: #154 