### PR TITLE
Fix some issues causing corruption when reading Amiga disks

### DIFF
--- a/arch/amiga/decoder.cc
+++ b/arch/amiga/decoder.cc
@@ -32,6 +32,8 @@ AbstractDecoder::RecordType AmigaDecoder::advanceToNextRecord()
 void AmigaDecoder::decodeSectorRecord()
 {
     const auto& rawbits = readRawBits(AMIGA_RECORD_SIZE*16);
+	if (rawbits < (AMIGA_RECORD_SIZE*16))
+		return;
     const auto& rawbytes = toBytes(rawbits).slice(0, AMIGA_RECORD_SIZE*2);
     const auto& bytes = decodeFmMfm(rawbits).slice(0, AMIGA_RECORD_SIZE);
 

--- a/arch/amiga/decoder.cc
+++ b/arch/amiga/decoder.cc
@@ -32,7 +32,7 @@ AbstractDecoder::RecordType AmigaDecoder::advanceToNextRecord()
 void AmigaDecoder::decodeSectorRecord()
 {
     const auto& rawbits = readRawBits(AMIGA_RECORD_SIZE*16);
-	if (rawbits < (AMIGA_RECORD_SIZE*16))
+	if (rawbits.size() < (AMIGA_RECORD_SIZE*16))
 		return;
     const auto& rawbytes = toBytes(rawbits).slice(0, AMIGA_RECORD_SIZE*2);
     const auto& bytes = decodeFmMfm(rawbits).slice(0, AMIGA_RECORD_SIZE);

--- a/lib/reader.cc
+++ b/lib/reader.cc
@@ -261,13 +261,13 @@ void readDiskCommand(AbstractDecoder& decoder)
         if (dumpSectors)
         {
             std::cout << "\nDecoded sectors follow:\n\n";
-            for (auto& i : readSectors)
+            for (auto& sector : track->sectors)
             {
-                auto& sector = i.second;
-				std::cout << fmt::format("{}.{:02}.{:02}: I+{:.2f}us with {:.2f}us clock\n",
-                            sector->logicalTrack, sector->logicalSide, sector->logicalSector,
-                            sector->position.ns() / 1000.0, sector->clock / 1000.0);
-				hexdump(std::cout, sector->data);
+				std::cout << fmt::format("{}.{:02}.{:02}: I+{:.2f}us with {:.2f}us clock: status {}\n",
+                            sector.logicalTrack, sector.logicalSide, sector.logicalSector,
+                            sector.position.ns() / 1000.0, sector.clock / 1000.0,
+							sector.status);
+				hexdump(std::cout, sector.data);
 				std::cout << std::endl;
             }
         }


### PR DESCRIPTION
The Amiga disk checksum algorithm is trash; I'm seeing a lot of spurious false positives, including a completely truncated sector being marked as good (because the checksum of 00 00 00 00... is 0). Plus, two bit errors in the same sector can cancel out and not be detected.
