### PR TITLE
Fix a crash when decoding MX disks if advanceToNextRecord finds no records in a track.

### DIFF
--- a/arch/mx/decoder.cc
+++ b/arch/mx/decoder.cc
@@ -37,7 +37,7 @@ AbstractDecoder::RecordType MxDecoder::advanceToNextRecord()
         const FluxMatcher* matcher = nullptr;
         _sector->clock = _clock = _fmr->seekToPattern(ID_PATTERN, matcher);
         readRawBits(32); /* skip the ID mark */
-        _logicalTrack = decodeFmMfm(readRawBits(32)).reader().read_be16();
+        _logicalTrack = decodeFmMfm(readRawBits(32)).slice(0, 32).reader().read_be16();
     }
     else if (_currentSector == 10)
     {

--- a/src/fe-scptoflux.cc
+++ b/src/fe-scptoflux.cc
@@ -16,7 +16,7 @@ static int endSide;
 
 static void syntax()
 {
-    std::cout << "Syntax: fluxengine convert cwftoflux <cwffile> <fluxfile>\n";
+    std::cout << "Syntax: fluxengine convert scptoflux <scpfile> <fluxfile>\n";
     exit(0);
 }
 


### PR DESCRIPTION
See title.

Fixes: #169 