### PR TITLE
Add firmware support for hard sectors

### DIFF
--- a/lib/fluxsink/fluxsink.h
+++ b/lib/fluxsink/fluxsink.h
@@ -24,6 +24,7 @@ public:
 };
 
 extern void setHardwareFluxSinkDensity(bool high_density);
+extern void setHardwareFluxSinkHardSectorCount(int sectorCount);
 
 #endif
 

--- a/lib/fluxsink/hardwarefluxsink.cc
+++ b/lib/fluxsink/hardwarefluxsink.cc
@@ -39,6 +39,7 @@ public:
     {
 		if (hardSectorCount.get())
 		{
+			usbSetDrive(_drive, high_density, indexMode);
 			std::cerr << "Measuring rotational speed... " << std::flush;
 			nanoseconds_t oneRevolution = usbGetRotationalPeriod(hardSectorCount);
 			_hardSectorThreshold = oneRevolution * 3 / (4 * hardSectorCount);

--- a/lib/fluxsource/fluxsource.h
+++ b/lib/fluxsource/fluxsource.h
@@ -30,6 +30,7 @@ public:
 extern void setHardwareFluxSourceRevolutions(double revolutions);
 extern void setHardwareFluxSourceDensity(bool high_density);
 extern void setHardwareFluxSourceSynced(bool synced);
+extern void setHardwareFluxSourceHardSectorCount(int sectorCount);
 
 #endif
 

--- a/lib/reader.cc
+++ b/lib/reader.cc
@@ -91,6 +91,11 @@ void setReaderRevolutions(int revolutions)
 	setHardwareFluxSourceRevolutions(revolutions);
 }
 
+void setReaderHardSectorCount(int sectorCount)
+{
+    setHardwareFluxSourceHardSectorCount(sectorCount);
+}
+
 static void writeSectorsToFile(const SectorSet& sectors, const ImageSpec& spec)
 {
 	std::unique_ptr<ImageWriter> writer(ImageWriter::create(sectors, spec));

--- a/lib/reader.h
+++ b/lib/reader.h
@@ -13,6 +13,7 @@ extern FlagGroup readerFlags;
 extern void setReaderDefaultSource(const std::string& source);
 extern void setReaderDefaultOutput(const std::string& output);
 extern void setReaderRevolutions(int revolutions);
+extern void setReaderHardSectorCount(int sectorCount);
 
 extern std::vector<std::unique_ptr<Track>> readTracks();
 

--- a/lib/usb/fluxengineusb.cc
+++ b/lib/usb/fluxengineusb.cc
@@ -144,9 +144,12 @@ public:
 		await_reply<struct any_frame>(F_FRAME_RECALIBRATE_REPLY);
 	}
 
-	nanoseconds_t getRotationalPeriod(void)
+	nanoseconds_t getRotationalPeriod(int hardSectorCount)
 	{
-		struct any_frame f = { .f = {.type = F_FRAME_MEASURE_SPEED_CMD, .size = sizeof(f)} };
+		struct measurespeed_frame f = {
+			.f = {.type = F_FRAME_MEASURE_SPEED_CMD, .size = sizeof(f)},
+			.hard_sector_count = (uint8_t) hardSectorCount,
+		};
 		usb_cmd_send(&f, f.f.size);
 
 		auto r = await_reply<struct speed_frame>(F_FRAME_MEASURE_SPEED_REPLY);
@@ -227,12 +230,15 @@ public:
 		await_reply<struct any_frame>(F_FRAME_BULK_READ_TEST_REPLY);
 	}
 
-	Bytes read(int side, bool synced, nanoseconds_t readTime)
+	Bytes read(int side, bool synced, nanoseconds_t readTime,
+	           nanoseconds_t hardSectorThreshold)
 	{
+		hardSectorThreshold += 5e5; /* Round to nearest ms. */
 		struct read_frame f = {
 			.f = { .type = F_FRAME_READ_CMD, .size = sizeof(f) },
 			.side = (uint8_t) side,
-			.synced = (uint8_t) synced
+			.synced = (uint8_t) synced,
+			.hardsec_threshold_ms = (uint8_t) (hardSectorThreshold / 1e6),
 		};
 		uint16_t milliseconds = readTime / 1e6;
 		((uint8_t*)&f.milliseconds)[0] = milliseconds;
@@ -249,14 +255,16 @@ public:
 		return buffer;
 	}
 
-	void write(int side, const Bytes& bytes)
+	void write(int side, const Bytes& bytes, nanoseconds_t hardSectorThreshold)
 	{
 		unsigned safelen = bytes.size() & ~(FRAME_SIZE-1);
 		Bytes safeBytes = bytes.slice(0, safelen);
+		hardSectorThreshold += 5e5; /* Round to nearest ms. */
 
 		struct write_frame f = {
 			.f = { .type = F_FRAME_WRITE_CMD, .size = sizeof(f) },
 			.side = (uint8_t) side,
+			.hardsec_threshold_ms = (uint8_t) (hardSectorThreshold / 1e6),
 		};
 		((uint8_t*)&f.bytes_to_write)[0] = safelen;
 		((uint8_t*)&f.bytes_to_write)[1] = safelen >> 8;
@@ -269,11 +277,13 @@ public:
 		await_reply<struct any_frame>(F_FRAME_WRITE_REPLY);
 	}
 
-	void erase(int side)
+	void erase(int side, nanoseconds_t hardSectorThreshold)
 	{
+		hardSectorThreshold += 5e5; /* Round to nearest ms. */
 		struct erase_frame f = {
 			.f = { .type = F_FRAME_ERASE_CMD, .size = sizeof(f) },
 			.side = (uint8_t) side,
+			.hardsec_threshold_ms = (uint8_t) (hardSectorThreshold / 1e6),
 		};
 		usb_cmd_send(&f, f.f.size);
 

--- a/lib/usb/usb.h
+++ b/lib/usb/usb.h
@@ -15,12 +15,14 @@ public:
 	virtual int getVersion() = 0;
 	virtual void recalibrate() = 0;
 	virtual void seek(int track) = 0;
-	virtual nanoseconds_t getRotationalPeriod() = 0;
+	virtual nanoseconds_t getRotationalPeriod(int hardSectorCount) = 0;
 	virtual void testBulkWrite() = 0;
 	virtual void testBulkRead() = 0;
-	virtual Bytes read(int side, bool synced, nanoseconds_t readTime) = 0;
-	virtual void write(int side, const Bytes& bytes) = 0;
-	virtual void erase(int side) = 0;
+	virtual Bytes read(int side, bool synced, nanoseconds_t readTime,
+	                   nanoseconds_t hardSectorThreshold) = 0;
+	virtual void write(int side, const Bytes& bytes,
+	                   nanoseconds_t hardSectorThreshold) = 0;
+	virtual void erase(int side, nanoseconds_t hardSectorThreshold) = 0;
 	virtual void setDrive(int drive, bool high_density, int index_mode) = 0;
 	virtual void measureVoltages(struct voltages_frame* voltages) = 0;
 
@@ -40,16 +42,20 @@ static inline void usbRecalibrate()   { getUsb().recalibrate(); }
 static inline void usbSeek(int track) { getUsb().seek(track); }
 static inline void usbTestBulkWrite() { getUsb().testBulkWrite(); }
 static inline void usbTestBulkRead()  { getUsb().testBulkRead(); }
-static inline void usbErase(int side) { getUsb().erase(side); }
 
-static inline nanoseconds_t usbGetRotationalPeriod()
-{ return getUsb().getRotationalPeriod(); }
+static inline void usbErase(int side, nanoseconds_t hardSectorThreshold)
+{ getUsb().erase(side, hardSectorThreshold); }
 
-static inline Bytes usbRead(int side, bool synced, nanoseconds_t readTime)
-{ return getUsb().read(side, synced, readTime); }
+static inline nanoseconds_t usbGetRotationalPeriod(int hardSectorCount)
+{ return getUsb().getRotationalPeriod(hardSectorCount); }
 
-static inline void usbWrite(int side, const Bytes& bytes)
-{ getUsb().write(side, bytes); }
+static inline Bytes usbRead(int side, bool synced, nanoseconds_t readTime,
+                            nanoseconds_t hardSectorThreshold)
+{ return getUsb().read(side, synced, readTime, hardSectorThreshold); }
+
+static inline void usbWrite(int side, const Bytes& bytes,
+                            nanoseconds_t hardSectorThreshold)
+{ getUsb().write(side, bytes, hardSectorThreshold); }
 
 static inline void usbSetDrive(int drive, bool high_density, int index_mode)
 { getUsb().setDrive(drive, high_density, index_mode); }

--- a/lib/writer.cc
+++ b/lib/writer.cc
@@ -43,6 +43,11 @@ void setWriterDefaultInput(const std::string& input)
     ::input.set(input);
 }
 
+void setWriterHardSectorCount(int sectorCount)
+{
+	setHardwareFluxSinkHardSectorCount(sectorCount);
+}
+
 static SectorSet readSectorsFromFile(const ImageSpec& spec)
 {
 	return ImageReader::create(spec)->readImage();

--- a/lib/writer.h
+++ b/lib/writer.h
@@ -11,6 +11,7 @@ class Geometry;
 
 extern void setWriterDefaultDest(const std::string& dest);
 extern void setWriterDefaultInput(const std::string& input);
+extern void setWriterHardSectorCount(int sectorCount);
 
 extern void writeTracks(const std::function<std::unique_ptr<Fluxmap>(int track, int side)> producer);
 

--- a/protocol.h
+++ b/protocol.h
@@ -3,7 +3,7 @@
 
 enum 
 {
-    FLUXENGINE_VERSION = 14,
+    FLUXENGINE_VERSION = 15,
 
     FLUXENGINE_VID = 0x1209,
     FLUXENGINE_PID = 0x6e00,
@@ -48,7 +48,7 @@ enum
     F_FRAME_GET_VERSION_REPLY,    /* version_frame */
     F_FRAME_SEEK_CMD,             /* seek_frame */
     F_FRAME_SEEK_REPLY,           /* any_frame */
-    F_FRAME_MEASURE_SPEED_CMD,    /* any_frame */
+    F_FRAME_MEASURE_SPEED_CMD,    /* measurespeed_frame */
     F_FRAME_MEASURE_SPEED_REPLY,  /* speed_frame */
     F_FRAME_BULK_WRITE_TEST_CMD,   /* any_frame */
     F_FRAME_BULK_WRITE_TEST_REPLY, /* any_frame */
@@ -125,6 +125,12 @@ struct seek_frame
     uint8_t track;
 };
 
+struct measurespeed_frame 
+{
+    struct frame_header f;
+	uint8_t hard_sector_count;
+};
+
 struct speed_frame
 {
     struct frame_header f;
@@ -137,6 +143,7 @@ struct read_frame
     uint8_t side;
     uint8_t synced;
     uint16_t milliseconds;
+    uint8_t hardsec_threshold_ms;
 };
 
 struct write_frame
@@ -144,12 +151,14 @@ struct write_frame
     struct frame_header f;
     uint8_t side;
     uint32_t bytes_to_write;
+    uint8_t hardsec_threshold_ms;
 };
 
 struct erase_frame
 {
     struct frame_header f;
     uint8_t side;
+    uint8_t hardsec_threshold_ms;
 };
 
 struct set_drive_frame

--- a/src/fe-readmicropolis.cc
+++ b/src/fe-readmicropolis.cc
@@ -16,7 +16,7 @@ int mainReadMicropolis(int argc, const char* argv[])
 {
 	setReaderDefaultSource(":t=0-76");
 	setReaderDefaultOutput("micropolis.img");
-	setReaderRevolutions(21); /* 17 index holes * 1.25 */
+	setReaderHardSectorCount(16);
 	flags.parseFlags(argc, argv);
 
 	MicropolisDecoder decoder;

--- a/src/fe-rpm.cc
+++ b/src/fe-rpm.cc
@@ -13,13 +13,18 @@ static DataSpecFlag source(
     "source for data",
     ":d=0:t=0:s=0");
 
+static IntFlag hardSectorCount(
+    { "--hard-sector-count" },
+    "number of hard sectors on the disk (0=soft sectors)",
+    0);
+
 int mainRpm(int argc, const char* argv[])
 {
     flags.parseFlags(argc, argv);
 
     FluxSpec spec(source);
     usbSetDrive(spec.drive, false, F_INDEX_REAL);
-    nanoseconds_t period = usbGetRotationalPeriod();
+    nanoseconds_t period = usbGetRotationalPeriod(hardSectorCount);
     if (period != 0)
         std::cout << "Rotational period is " << period/1000000 << " ms (" << 60e9/period << " rpm)" << std::endl;
     else


### PR DESCRIPTION
Feel free to rip this apart. I would have discussed first, but things sort of fell into place and then it actually worked the first time it compiled...

Write support is untested, but that is the purpose and real goal. I hadn't added write support for Micropolis because the writes need to be aligned to the start of the track. I have not tested with retro hardware, but I have tested with the Micropolis support I added to FlashFloppy with some local changes to improve index timing (based on logic analyzer). It doesn't really impact reads much, but it appears to be working as `rpm` now produces consistent and correct results and things like `--sync-with-index true --revolutions .9` produce properly-aligned errors.

It'll be at least a month until I have access to Micropolis hardware again, for further testing and verification.

Edit: I've now tested writing for Micropolis (future PR), and the write stream is properly synchronized to the start of the track when viewed with a logic analyzer.