### PR TITLE
Write Atari ST formats

### DIFF
--- a/doc/disk-atarist.md
+++ b/doc/disk-atarist.md
@@ -1,0 +1,73 @@
+Disk: Atari ST
+==============
+
+Atari ST disks are standard MFM encoded IBM scheme disks without an IAM header.
+Disks are typically formatted 512 bytes per sector with between 9-10 (sometimes
+11!) sectors per track and 80-82 tracks per side.
+
+
+Reading disks
+-------------
+
+Just do:
+
+    fluxengine read atarist
+
+...and you'll end up with an `atarist.st` file. The size of the disk image will
+vary depending on the format.
+
+Writing disks
+-------------
+
+FluxEngine can also write Atari ST scheme disks.
+
+The syntax is:
+
+    fluxengine write atarist -i input.st <options>
+
+The format of `input.st` will vary depending on the kind of disk you're writing,
+which is configured by the options. By default FluxEngine will write an 80
+track, 9 sector, double-sided disk. If that doesn't match your target format you
+will need to pass some options. There are some presets, which you will almost
+certainly want to use if possible:
+
+  - `--st-preset-360`: a 360kB 3.5" disk, with 80 cylinders,
+  1 side, and 9 sectors per track.
+  - `--st-preset-370`: a 370kB 3.5" disk, with 82 cylinders,
+  1 side, and 9 sectors per track.
+  - `--st-preset-400`: a 400kB 3.5" disk, with 80 cylinders,
+  1 side, and 10 sectors per track.
+  - `--st-preset-410`: a 410kB 3.5" disk, with 82 cylinders,
+  1 side, and 10 sectors per track.
+  - `--st-preset-720`: a 720kB 3.5" disk, with 80 cylinders,
+  2 sides, and 9 sectors per track.
+  - `--st-preset-740`: a 740kB 3.5" disk, with 82 cylinders,
+  2 sides, and 9 sectors per track.
+  - `--st-preset-800`: a 800kB 3.5" disk, with 80 cylinders,
+  2 sides, and 10 sectors per track.
+  - `--st-preset-820`: a 820kB 3.5" disk, with 82 cylinders,
+  2 sides, and 10 sectors per track.
+
+These options simply preset the output destination flag (`-d`) and the
+following, lower-level options. Note that options are processed left to right,
+so it's possible to use a preset and then change some settings. To see the
+values for a preset, simply append `--help`.
+  - `--st-sector-size=N`: the size of a sector, in bytes. Must be a power of
+  two.
+  - `--st-gap1-bytes=N`: the size of gap 1 in bytes (between the IAM record
+  and the first sector record).
+  - `--st-gap2-bytes=N`: the size of gap 2 in bytes (between each sector
+  record and the data record).
+  - `--st-gap3-bytes=N`: the size of gap 3 in bytes (between the data record
+  and the next sector record).
+  - `--st-sector-skew=0123...`: a string representing the order in which to
+  write sectors: each character represents on sector, with `0` being the
+  first. Sectors 10 and above are represented as letters from `A` up.
+
+
+Useful references
+-----------------
+
+  - [Atari ST Floppy Drive Hardware Information](https://info-coach.fr/atari/hardware/FD-Hard.php) by Jean Louis-Guerin
+
+  - [Atari ST Floppy Drive Software Information](https://info-coach.fr/atari/software/FD-Soft.php) by Jean Louis-Guerin

--- a/doc/disk-ibm.md
+++ b/doc/disk-ibm.md
@@ -116,7 +116,7 @@ then change some settings. To see the values for a preset, simply append
   - `--ibm-sector-skew=0123...`: a string representing the order in which to
   write sectors: each character represents on sector, with `0` being the
   first (always, regardless of `--ibm-start-sector-id` above). Sectors 10 and
-  above are represented as latters from `A` up.
+  above are represented as letters from `A` up.
 
 Mixed-format disks
 ------------------

--- a/lib/imagereader/imagereader.cc
+++ b/lib/imagereader/imagereader.cc
@@ -18,6 +18,7 @@ std::map<std::string, ImageReader::Constructor> ImageReader::formats =
 	{".ima", ImageReader::createImgImageReader},
 	{".jv1", ImageReader::createImgImageReader},
 	{".jv3", ImageReader::createJv3ImageReader},
+	{".st", ImageReader::createImgImageReader},
 };
 
 ImageReader::Constructor ImageReader::findConstructor(const ImageSpec& spec)

--- a/lib/imagewriter/imagewriter.cc
+++ b/lib/imagewriter/imagewriter.cc
@@ -17,6 +17,7 @@ std::map<std::string, ImageWriter::Constructor> ImageWriter::formats =
 	{".diskcopy", ImageWriter::createDiskCopyImageWriter},
 	{".img", ImageWriter::createImgImageWriter},
 	{".ldbs", ImageWriter::createLDBSImageWriter},
+	{".st", ImageWriter::createImgImageWriter},
 };
 
 ImageWriter::Constructor ImageWriter::findConstructor(const ImageSpec& spec)

--- a/mkninja.sh
+++ b/mkninja.sh
@@ -232,6 +232,7 @@ buildlibrary libfrontend.a \
     src/fe-readamiga.cc \
     src/fe-readampro.cc \
     src/fe-readapple2.cc \
+    src/fe-readatarist.cc \
     src/fe-readbrother.cc \
     src/fe-readc64.cc \
     src/fe-readdfs.cc \

--- a/mkninja.sh
+++ b/mkninja.sh
@@ -251,6 +251,7 @@ buildlibrary libfrontend.a \
     src/fe-testvoltages.cc \
     src/fe-upgradefluxfile.cc \
     src/fe-writeamiga.cc \
+    src/fe-writeatarist.cc \
     src/fe-writebrother.cc \
     src/fe-writeibm.cc \
     src/fe-writemac.cc \

--- a/src/fe-readatarist.cc
+++ b/src/fe-readatarist.cc
@@ -1,0 +1,24 @@
+#include "globals.h"
+#include "flags.h"
+#include "reader.h"
+#include "fluxmap.h"
+#include "decoders/decoders.h"
+#include "sector.h"
+#include "sectorset.h"
+#include "record.h"
+#include "dataspec.h"
+#include "ibm/ibm.h"
+#include "fmt/format.h"
+
+static FlagGroup flags { &readerFlags };
+
+int mainReadAtariST(int argc, const char* argv[])
+{
+	setReaderDefaultSource(":t=0-79:s=0-1");
+	setReaderDefaultOutput("atarist.st");
+    flags.parseFlags(argc, argv);
+
+	IbmDecoder decoder(1);
+	readDiskCommand(decoder);
+    return 0;
+}

--- a/src/fe-writeatarist.cc
+++ b/src/fe-writeatarist.cc
@@ -1,0 +1,132 @@
+#include "globals.h"
+#include "flags.h"
+#include "decoders/decoders.h"
+#include "encoders/encoders.h"
+#include "ibm/ibm.h"
+#include "writer.h"
+#include "fmt/format.h"
+#include <fstream>
+
+static FlagGroup flags { &writerFlags };
+
+static IntFlag sectorSize(
+	{ "--st-sector-size" },
+	"Size of the sectors to write (bytes).",
+	512);
+static IntFlag gap1(
+	{ "--st-gap1-bytes" },
+	"Size of gap 1 (the post-index gap).",
+	60);
+
+static IntFlag gap2(
+	{ "--st-gap2-bytes" },
+	"Size of gap 2 (the post-ID gap).",
+	22);
+
+static IntFlag gap3(
+	{ "--st-gap3-bytes" },
+	"Size of gap 3 (the post-data or format gap).",
+	40);
+
+static StringFlag sectorSkew(
+	{ "--st-sector-skew" },
+	"Order to emit sectors.",
+	"");
+
+static ActionFlag preset360(
+	{ "--st-preset-360" },
+	"Preset parameters to a 3.5\" 360kB disk (1 side, 80 tracks, 9 sectors).",
+	[] {
+		setWriterDefaultDest(":d=0:s=0:t=0-79");
+		setWriterDefaultInput(":c=80:h=1:s=9:b=512");
+		sectorSkew.setDefaultValue("012345678");
+	});
+
+static ActionFlag preset370(
+	{ "--st-preset-380" },
+	"Preset parameters to a 3.5\" 370kB disk (1 side, 82 tracks, 9 sectors).",
+	[] {
+		setWriterDefaultDest(":d=0:s=0:t=0-81");
+		setWriterDefaultInput(":c=82:h=1:s=9:b=512");
+		sectorSkew.setDefaultValue("012345678");
+	});
+
+static ActionFlag preset400(
+	{ "--st-preset-400" },
+	"Preset parameters to a 3.5\" 400kB disk (1 side, 80 Tracks, 10 sectors).",
+	[] {
+		setWriterDefaultDest(":d=0:s=0:t=0-79");
+		setWriterDefaultInput(":c=80:h=1:s=10:b=512");
+		sectorSkew.setDefaultValue("0123456789");
+	});
+
+static ActionFlag preset410(
+	{ "--st-preset-410" },
+	"Preset parameters to a 3.5\" 410kB disk (1 side, 82 tracks, 10 sectors).",
+	[] {
+		setWriterDefaultDest(":d=0:s=0:t=0-81");
+		setWriterDefaultInput(":c=82:h=1:s=10:b=512");
+		sectorSkew.setDefaultValue("0123456789");
+	});
+
+static ActionFlag preset720(
+	{ "--st-preset-720" },
+	"Preset parameters to a 3.5\" 720kB disk (2 sides, 80 tracks, 9 sectors).",
+	[] {
+		setWriterDefaultDest(":d=0:s=0-1:t=0-79");
+		setWriterDefaultInput(":c=80:h=2:s=9:b=512");
+		sectorSkew.setDefaultValue("012345678");
+	});
+
+static ActionFlag preset740(
+	{ "--st-preset-740" },
+	"Preset parameters to a 3.5\" 740kB disk (2 sides, 82 tracks, 9 sectors).",
+	[] {
+		setWriterDefaultDest(":d=0:s=0-1:t=0-81");
+		setWriterDefaultInput(":c=82:h=2:s=9:b=512");
+		sectorSkew.setDefaultValue("012345678");
+	});
+
+static ActionFlag preset800(
+	{ "--st-preset-800" },
+	"Preset parameters to a 3.5\" 800kB disk (2 sides, 80 tracks, 10 sectors).",
+	[] {
+		setWriterDefaultDest(":d=0:s=0-1:t=0-79");
+		setWriterDefaultInput(":c=80:h=2:s=10:b=512");
+		sectorSkew.setDefaultValue("0123456789");
+	});
+
+static ActionFlag preset820(
+	{ "--st-preset-820" },
+	"Preset parameters to a 3.5\" 820kB disk (2 sides, 82 tracks, 10 sectors).",
+	[] {
+		setWriterDefaultDest(":d=0:s=0-1:t=0-81");
+		setWriterDefaultInput(":c=82:h=2:s=10:b=512");
+		sectorSkew.setDefaultValue("0123456789");
+	});
+
+int mainWriteAtariST(int argc, const char* argv[])
+{
+	setWriterDefaultDest(":d=0:t=0-79:s=0-1");
+	flags.parseFlags(argc, argv);
+
+	IbmParameters parameters;
+	parameters.trackLengthMs = 200;
+	parameters.sectorSize = sectorSize;
+	parameters.emitIam = false;
+	parameters.startSectorId = 1;
+	parameters.clockRateKhz = 250;
+ 	parameters.useFm = false;
+	parameters.idamByte = 0x5554;
+	parameters.damByte = 0x5545;
+	parameters.gap0 = 0;
+	parameters.gap1 = gap1;
+	parameters.gap2 = gap2;
+	parameters.gap3 = gap3;
+	parameters.sectorSkew = sectorSkew;
+
+	IbmEncoder encoder(parameters);
+	writeDiskCommand(encoder);
+
+    return 0;
+}

--- a/src/fluxengine.cc
+++ b/src/fluxengine.cc
@@ -34,6 +34,7 @@ extern command_cb mainTestBandwidth;
 extern command_cb mainTestVoltages;
 extern command_cb mainUpgradeFluxFile;
 extern command_cb mainWriteAmiga;
+extern command_cb mainWriteAtariST;
 extern command_cb mainWriteBrother;
 extern command_cb mainWriteIbm;
 extern command_cb mainWriteMac;
@@ -98,6 +99,7 @@ static std::vector<Command> writeables =
     { "ibm",           mainWriteIbm,      "Writes the ubiquitous IBM format disks.", },
 	{ "mac", 		   mainWriteMac,      "Writes Apple Macintosh disks.", },
 	{ "tids990",       mainWriteTiDs990,  "Writes Texas Instruments DS990 disks.", },
+    { "atarist",       mainWriteAtariST,  "Writes Atari ST disks."}
 };
 
 static std::vector<Command> convertables =

--- a/src/fluxengine.cc
+++ b/src/fluxengine.cc
@@ -16,6 +16,7 @@ extern command_cb mainReadAESLanier;
 extern command_cb mainReadAmiga;
 extern command_cb mainReadAmpro;
 extern command_cb mainReadApple2;
+extern command_cb mainReadAtariST;
 extern command_cb mainReadBrother;
 extern command_cb mainReadC64;
 extern command_cb mainReadDFS;
@@ -78,6 +79,7 @@ static std::vector<Command> readables =
     { "amiga",         mainReadAmiga,     "Reads Commodore Amiga disks.", },
     { "ampro",         mainReadAmpro,     "Reads Ampro disks.", },
     { "apple2",        mainReadApple2,    "Reads Apple II disks.", },
+    { "atarist",       mainReadAtariST,   "Reads Atari ST disks.", },
     { "brother",       mainReadBrother,   "Reads 120kB and 240kB Brother word processor disks.", },
     { "c64",           mainReadC64,       "Reads Commodore 64 disks.", },
     { "dfs",           mainReadDFS,       "Reads Acorn DFS disks.", },
@@ -95,11 +97,11 @@ static std::vector<Command> readables =
 static std::vector<Command> writeables =
 {
     { "amiga",         mainWriteAmiga,    "Writes Amiga disks.", },
+    { "atarist",       mainWriteAtariST,  "Writes Atari ST disks.", },
     { "brother",       mainWriteBrother,  "Writes 120kB and 240kB Brother word processor disks.", },
     { "ibm",           mainWriteIbm,      "Writes the ubiquitous IBM format disks.", },
-	{ "mac", 		   mainWriteMac,      "Writes Apple Macintosh disks.", },
+	{ "mac",           mainWriteMac,      "Writes Apple Macintosh disks.", },
 	{ "tids990",       mainWriteTiDs990,  "Writes Texas Instruments DS990 disks.", },
-    { "atarist",       mainWriteAtariST,  "Writes Atari ST disks."}
 };
 
 static std::vector<Command> convertables =


### PR DESCRIPTION
This PR addresses #201.

It adds a new write option for creating Atari ST disks and registers the standard `.st` file extension so disk images can be used without having to rename them first. The standard IBM writer is used but many of the options are preset for ST disks (no IAM, fixed clock rates / speeds etc.).

Atari ST disks can be written using:

```
fluxengine write atarist --st-preset-820 -i my-disk-image.st 
```


The following format presets are available:

flag | format
-|-
--st-preset-360 | 360kB disk (1 side, 80 tracks, 9 sectors)
--st-preset-370 | 370kB disk (1 side, 82 tracks, 9 sectors)
--st-preset-400 | 400kB disk (1 side, 80 Tracks, 10 sectors)
--st-preset-410 | 410kB disk (1 side, 82 tracks, 10 sectors)
--st-preset-720 | 720kB disk (2 sides, 80 tracks, 9 sectors)
--st-preset-740 | 740kB disk (2 sides, 82 tracks, 9 sectors)
--st-preset-800 | 800kB disk (2 sides, 80 tracks, 10 sectors)
--st-preset-820 | 820kB disk (2 sides, 82 tracks, 10 sectors)