### PR TITLE
added parameter swapSides to IBM encoder

### DIFF
--- a/arch/ibm/encoder.cc
+++ b/arch/ibm/encoder.cc
@@ -102,6 +102,8 @@ static uint8_t decodeUint16(uint16_t raw)
 std::unique_ptr<Fluxmap> IbmEncoder::encode(
 	int physicalTrack, int physicalSide, const SectorSet& allSectors)
 {
+	if (_parameters.swapSides)
+		physicalSide = 1 - physicalSide;
 	double clockRateUs = 1e3 / _parameters.clockRateKhz;
 	if (!_parameters.useFm)
 		clockRateUs /= 2.0;

--- a/arch/ibm/ibm.h
+++ b/arch/ibm/ibm.h
@@ -69,6 +69,7 @@ struct IbmParameters
 	int gap2;
 	int gap3;
 	std::string sectorSkew;
+	bool swapSides;
 };
 
 class IbmEncoder : public AbstractEncoder

--- a/src/fe-writeibm.cc
+++ b/src/fe-writeibm.cc
@@ -74,6 +74,11 @@ static StringFlag sectorSkew(
 	"Order to emit sectors.",
 	"");
 
+static BoolFlag swapSides(
+	{ "--ibm-swap-sides" },
+	"Swap sides while writing. Needed for Commodore 1581, CMD FD-2000, Thomson TO7.",
+	false);
+
 static ActionFlag preset1440(
 	{ "--ibm-preset-1440" },
 	"Preset parameters to a 3.5\" 1440kB disk.",
@@ -129,10 +134,10 @@ int mainWriteIbm(int argc, const char* argv[])
 	parameters.gap2 = gap2;
 	parameters.gap3 = gap3;
 	parameters.sectorSkew = sectorSkew;
+	parameters.swapSides = swapSides;
 
 	IbmEncoder encoder(parameters);
 	writeDiskCommand(encoder);
 
     return 0;
 }
-


### PR DESCRIPTION
According to https://github.com/Distrotech/fdutils/blob/master/src/mediaprm there are some obscure disk drives out there that expect the sides 0 and 1 to be swapped (search for "swapsides"). We are talking about

- Commodore 1581 3.5" Disk Drive
- CMD FD-2000 (and FD-4000)
- Thomson TO7

Remark: I know nothing about the last one and so I don't know if it uses IBM encoding at all. But the Commodore related drives above do use IBM encoding

So for those special cases the IBM writer needs another parameter to deal with them, I came up with "swapSides" (bool).

The big question is: Is this now cumbersome for all those "ordinary" cases where presets have to provide a false value for swapSides - like for example the Atari ST presets in the other Pull Request.