### PR TITLE
Fix the timing when writing IBM 1440kB disks.

### DIFF
--- a/arch/ibm/encoder.cc
+++ b/arch/ibm/encoder.cc
@@ -205,7 +205,6 @@ std::unique_ptr<Fluxmap> IbmEncoder::encode(
 
 			Bytes truncatedData = sectorData->data.slice(0, _parameters.sectorSize);
 			bw += truncatedData;
-			hexdump(std::cout, data.slice(0, 64));
 			uint16_t crc = crc16(CCITT_POLY, data);
 			bw.write_be16(crc);
 

--- a/src/fe-writeibm.cc
+++ b/src/fe-writeibm.cc
@@ -88,7 +88,7 @@ static ActionFlag preset1440(
 		gap0.setDefaultValue(80);
 		gap1.setDefaultValue(50);
 		gap2.setDefaultValue(22);
-		gap3.setDefaultValue(108);
+		gap3.setDefaultValue(80);
 		sectorSkew.setDefaultValue("0123456789abcdefgh");
 	});
 


### PR DESCRIPTION
Turns out that gap3 for 1440kB disks was wrong, and with the firmware fix, tracks no longer fit on a 200ms disk.