### PR TITLE
Adding preset for Commodore 1581 (cbm1581) to IBM writer frontend

### DIFF
--- a/src/fe-writeibm.cc
+++ b/src/fe-writeibm.cc
@@ -95,6 +95,7 @@ static ActionFlag preset1440(
 		gap2.setDefaultValue(22);
 		gap3.setDefaultValue(80);
 		sectorSkew.setDefaultValue("0123456789abcdefgh");
+		swapSides.setDefaultValue(false);
 	});
 
 static ActionFlag preset720(
@@ -113,6 +114,27 @@ static ActionFlag preset720(
 		gap2.setDefaultValue(22);
 		gap3.setDefaultValue(80);
 		sectorSkew.setDefaultValue("012345678");
+		swapSides.setDefaultValue(false);
+	});
+
+static ActionFlag presetCBM1581(
+	{ "--ibm-preset-cbm1581" },
+	"Preset parameters to a 3.5\" 800kB disk.",
+	[] {
+		setWriterDefaultInput(":c=80:h=2:s=10:b=512");
+		trackLengthMs.setDefaultValue(200);
+		sectorSize.setDefaultValue(512);
+		startSectorId.setDefaultValue(1);
+		emitIam.setDefaultValue(false);
+		clockRateKhz.setDefaultValue(250);
+		idamByte.setDefaultValue(0x5554);
+		damByte.setDefaultValue(0x5545);
+		gap0.setDefaultValue(80);
+		gap1.setDefaultValue(80); //as emitIam is false this value remains unused
+		gap2.setDefaultValue(22);
+		gap3.setDefaultValue(34);
+		sectorSkew.setDefaultValue("0123456789");
+		swapSides.setDefaultValue(true);
 	});
 
 int mainWriteIbm(int argc, const char* argv[])


### PR DESCRIPTION
Hi,

Now this change is just a proposal - in two ways:

First, my preset for Commodore 1581 might not fit in well in this file - maybe it should get its own source file. (Especially as in a couple of days/weeks I will come up with a preset for CMD FD-2000 once I have found somebody who owns one and can confirm that the preset is ok. Some details regarding FD-2000 are in #107)

Secondly, the gap values of the 1581 preset are good enough for me and my tests with a real 1581 drive but might be matter of change once somebody reviews them / looks at diagrams, etc.

So this is just the current state of things and if you want - merge it, if not, it's ok for me - I can play with my 1581 images locally anyway.