### PR TITLE
Add presets for 5.25" IBM PC floppies.

### DIFF
--- a/src/fe-readibm.cc
+++ b/src/fe-readibm.cc
@@ -27,6 +27,29 @@ RangeFlag requiredSectors(
 	"A comma seperated list or range of sectors which must be on each track.",
 	"");
 
+static ActionFlag preset360(
+	{ "--ibm-preset-360" },
+	"Preset parameters for reading a 5.25\" 360kB disk in a 48tpi drive.",
+	[] {
+		setReaderDefaultSource(":t=0-39");
+		requiredSectors.set("0,1,2,3,4,5,6,7,8");
+	});
+
+static ActionFlag preset360hd(
+	{ "--ibm-preset-360-96tpi" },
+	"Preset parameters for reading a 5.25\" 360kB disk in a 96tpi drive.",
+	[] {
+		setReaderDefaultSource(":t=0-79x2");
+		requiredSectors.set("0,1,2,3,4,5,6,7,8");
+	});
+
+static ActionFlag preset1200(
+	{ "--ibm-preset-1200" },
+	"Preset parameters for reading a 5.25\" 1.2MB disk.",
+	[] {
+		requiredSectors.set("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14");
+	});
+
 int mainReadIBM(int argc, const char* argv[])
 {
 	setReaderDefaultSource(":t=0-79:s=0-1");


### PR DESCRIPTION
For reading:
    --ibm-preset-360 - Read a 5.25" 360kB disk in a 48tpi drive.
    --ibm-preset-360-96tpi - Read a 5.25" 360kB disk in a 96tpi
        drive.
    --ibm-preset-1200 - Read a 5.25" 1.2MB disk.

For writing:
    --ibm-preset-360 - Write a 5.25" 360kB disk in a 48tpi drive.
    --ibm-preset-1200 - Write a 5.25" 1.2MB disk in a 96tpi drive.

Test:
    Test reading and writing using a Teac FD-55GFR-571 96tpi drive.
    Test reading and writing using an Alps DFC222B05A 48tpi drive.

Fixes davidgiven/fluxengine#189
