### PR TITLE
Add support for slow drives and 40-track disks in 80-track drives.

### DIFF
--- a/FluxEngine.cydsn/main.c
+++ b/FluxEngine.cydsn/main.c
@@ -7,8 +7,8 @@
 #include "../protocol.h"
 
 #define MOTOR_ON_TIME 5000 /* milliseconds */
-#define STEP_INTERVAL_TIME 6 /* ms */
-#define STEP_SETTLING_TIME 50 /* ms */
+#define STEP_INTERVAL_TIME_DEFAULT 6 /* ms */
+#define STEP_SETTLING_TIME_DEFAULT 50 /* ms */
 
 #define DISKSTATUS_WPT    1
 #define DISKSTATUS_DSKCHG 2
@@ -30,6 +30,9 @@ static bool motor_on = false;
 static uint32_t motor_on_time = 0;
 static bool homed = false;
 static int current_track = 0;
+static bool double_step = false;
+static uint8_t step_interval_time = STEP_INTERVAL_TIME_DEFAULT;
+static uint8_t step_settling_time = STEP_SETTLING_TIME_DEFAULT;
 static struct set_drive_frame current_drive_flags;
 
 #define BUFFER_COUNT 64 /* the maximum */
@@ -225,7 +228,7 @@ static void step(int dir)
     STEP_REG_Write(dir | 2); /* step low */
     CyDelayUs(6);
     STEP_REG_Write(dir); /* step high again, drive moves now */
-    CyDelay(STEP_INTERVAL_TIME);
+    CyDelay(step_interval_time);
 }
 
 /* returns true if it looks like a drive is attached */
@@ -238,6 +241,7 @@ static bool home(void)
         if (TRACK0_REG_Read())
             return true;
         step(STEP_TOWARDS0);
+        CyWdtClear();
     }
     
     return false;
@@ -265,16 +269,22 @@ static void seek_to(int track)
         if (track > current_track)
         {
             step(STEP_AWAYFROM0);
+            if (double_step) {
+                step(STEP_AWAYFROM0);
+            }
             current_track++;
         }
         else if (track < current_track)
         {
             step(STEP_TOWARDS0);
+            if (double_step) {
+                step(STEP_TOWARDS0);
+            }
             current_track--;
         }
         CyWdtClear();
     }
-    CyDelay(STEP_SETTLING_TIME);
+    CyDelay(step_settling_time);
     
     TK43_REG_Write(track < 43); /* high if 0..42, low if 43 or up */
     print("finished seek");
@@ -720,7 +730,9 @@ static void cmd_set_drive(struct set_drive_frame* f)
     if (drive1_present && !drive0_present)
         f->drive = 1;
     set_drive_flags(f);
-    
+    step_interval_time = f->step_interval_time;
+    step_settling_time = f->step_settling_time;
+    double_step = f->double_step;
     DECLARE_REPLY_FRAME(struct any_frame, F_FRAME_SET_DRIVE_REPLY);
     send_reply((struct any_frame*) &r);
 }

--- a/lib/fluxsink/hardwarefluxsink.cc
+++ b/lib/fluxsink/hardwarefluxsink.cc
@@ -21,6 +21,21 @@ static IntFlag hardSectorCount(
     "number of hard sectors on the disk (0=soft sectors)",
     0);
 
+static BoolFlag doubleStep(
+    { "--write-double-step" },
+    "double-step 96tpi drives for 48tpi media",
+    false);
+
+static IntFlag stepIntervalTime(
+    { "--write-step-interval-time" },
+    "Head step interval time in milliseconds",
+    6);
+
+static IntFlag stepSettlingTime(
+    { "--write-step-settling-time" },
+    "Head step settling time in milliseconds",
+    50);
+
 void setHardwareFluxSinkDensity(bool high_density)
 {
 	::high_density = high_density;
@@ -39,7 +54,8 @@ public:
     {
 		if (hardSectorCount != 0)
 		{
-			usbSetDrive(_drive, high_density, indexMode);
+			usbSetDrive(_drive, high_density, indexMode,
+                stepIntervalTime, stepSettlingTime, doubleStep);
 			std::cerr << "Measuring rotational speed... " << std::flush;
 			nanoseconds_t oneRevolution = usbGetRotationalPeriod(hardSectorCount);
 			_hardSectorThreshold = oneRevolution * 3 / (4 * hardSectorCount);
@@ -56,7 +72,8 @@ public:
 public:
     void writeFlux(int track, int side, Fluxmap& fluxmap)
     {
-        usbSetDrive(_drive, high_density, indexMode);
+        usbSetDrive(_drive, high_density, indexMode,
+            stepIntervalTime, stepSettlingTime, doubleStep);
         usbSeek(track);
 
         return usbWrite(side, fluxmap.rawBytes(), _hardSectorThreshold);

--- a/lib/fluxsource/hardwarefluxsource.cc
+++ b/lib/fluxsource/hardwarefluxsource.cc
@@ -29,6 +29,21 @@ static IntFlag hardSectorCount(
     "number of hard sectors on the disk (0=soft sectors)",
     0);
 
+static BoolFlag doubleStep(
+    { "--double-step" },
+    "double-step 96tpi drives for 48tpi media",
+    false);
+
+static IntFlag stepIntervalTime(
+    { "--step-interval-time" },
+    "Head step interval time in milliseconds",
+    6);
+
+static IntFlag stepSettlingTime(
+    { "--step-settling-time" },
+    "Head step settling time in milliseconds",
+    50);
+
 static bool high_density = false;
 
 void setHardwareFluxSourceDensity(bool high_density)
@@ -42,7 +57,8 @@ public:
     HardwareFluxSource(unsigned drive):
         _drive(drive)
     {
-        usbSetDrive(_drive, high_density, indexMode);
+        usbSetDrive(_drive, high_density, indexMode,
+            stepIntervalTime, stepSettlingTime, doubleStep);
         std::cerr << "Measuring rotational speed... " << std::flush;
         _oneRevolution = usbGetRotationalPeriod(hardSectorCount);
 	if (hardSectorCount != 0)
@@ -59,7 +75,8 @@ public:
 public:
     std::unique_ptr<Fluxmap> readFlux(int track, int side)
     {
-        usbSetDrive(_drive, high_density, indexMode);
+        usbSetDrive(_drive, high_density, indexMode, stepIntervalTime,
+            stepSettlingTime, doubleStep);
         usbSeek(track);
         Bytes data = usbRead(
 			side, synced, revolutions * _oneRevolution, _hardSectorThreshold);

--- a/lib/imagewriter/imagewriter.cc
+++ b/lib/imagewriter/imagewriter.cc
@@ -115,7 +115,17 @@ void ImageWriter::printMap()
 	int badSectors = 0;
 	int missingSectors = 0;
 	int totalSectors = 0;
-	std::cout << "H.SS Tracks --->" << std::endl;
+	std::cout << "     Tracks -> 1         2         3         ";
+	if (spec.cylinders > 40) {
+			std::cout << "4         5         6         7         8";
+	}
+	std::cout << std::endl;
+	std::cout << "H.SS 0123456789012345678901234567890123456789";
+	if (spec.cylinders > 40) {
+		std::cout << "01234567890123456789012345678901234567890123";
+	}
+	std::cout << std::endl;
+
 	for (int head = 0; head < spec.heads; head++)
 	{
 		for (int sectorId = 0; sectorId < spec.sectors; sectorId++)

--- a/lib/usb/fluxengineusb.cc
+++ b/lib/usb/fluxengineusb.cc
@@ -287,13 +287,17 @@ public:
 		await_reply<struct any_frame>(F_FRAME_ERASE_REPLY);
 	}
 
-	void setDrive(int drive, bool high_density, int index_mode)
+	void setDrive(int drive, bool high_density, int index_mode,
+		      int step_interval_time, int step_settling_time, bool double_step)
 	{
 		struct set_drive_frame f = {
-			{ .type = F_FRAME_SET_DRIVE_CMD, .size = sizeof(f) },
-			.drive = (uint8_t) drive,
+			{.type = F_FRAME_SET_DRIVE_CMD, .size = sizeof(f) },
+			.drive = (uint8_t)drive,
 			.high_density = high_density,
-			.index_mode = (uint8_t) index_mode
+			.index_mode = (uint8_t)index_mode,
+			.step_interval_time = (uint8_t) step_interval_time,
+			.step_settling_time = (uint8_t) step_settling_time,
+			.double_step = (uint8_t)double_step
 		};
 		usb_cmd_send(&f, f.f.size);
 		await_reply<struct any_frame>(F_FRAME_SET_DRIVE_REPLY);

--- a/lib/usb/greaseweazleusb.cc
+++ b/lib/usb/greaseweazleusb.cc
@@ -366,7 +366,8 @@ public:
         do_command({ CMD_GET_FLUX_STATUS, 2 });
     }
     
-    void setDrive(int drive, bool high_density, int index_mode)
+    void setDrive(int drive, bool high_density, int index_mode,
+                  int stepIntervalTime, int stepSettlingTime, bool double_step)
     {
         do_command({ CMD_SELECT, 3, (uint8_t)drive });
         do_command({ CMD_MOTOR, 4, (uint8_t)drive, 1 });

--- a/lib/usb/usb.h
+++ b/lib/usb/usb.h
@@ -23,7 +23,8 @@ public:
 	virtual void write(int side, const Bytes& bytes,
 	                   nanoseconds_t hardSectorThreshold) = 0;
 	virtual void erase(int side, nanoseconds_t hardSectorThreshold) = 0;
-	virtual void setDrive(int drive, bool high_density, int index_mode) = 0;
+	virtual void setDrive(int drive, bool high_density, int index_mode,
+		int step_interval_time, int step_settling_time, bool double_step) = 0;
 	virtual void measureVoltages(struct voltages_frame* voltages) = 0;
 
 protected:
@@ -58,8 +59,10 @@ static inline void usbWrite(int side, const Bytes& bytes,
                             nanoseconds_t hardSectorThreshold)
 { getUsb().write(side, bytes, hardSectorThreshold); }
 
-static inline void usbSetDrive(int drive, bool high_density, int index_mode)
-{ getUsb().setDrive(drive, high_density, index_mode); }
+static inline void usbSetDrive(int drive, bool high_density, int index_mode,
+	int step_interval_time, int step_settling_time, bool double_step)
+{ getUsb().setDrive(drive, high_density, index_mode,
+	step_interval_time, step_settling_time, double_step); }
 
 static inline void usbMeasureVoltages(struct voltages_frame* voltages)
 { getUsb().measureVoltages(voltages); }

--- a/protocol.h
+++ b/protocol.h
@@ -167,6 +167,9 @@ struct set_drive_frame
     uint8_t drive;
     uint8_t high_density;
     uint8_t index_mode;
+    uint8_t step_interval_time;
+    uint8_t step_settling_time;
+    uint8_t double_step;
 };
 
 struct voltages

--- a/src/fe-analysedriveresponse.cc
+++ b/src/fe-analysedriveresponse.cc
@@ -186,7 +186,7 @@ int mainAnalyseDriveResponse(int argc, const char* argv[])
 	if (spec.locations.size() != 1)
 		Error() << "the destination dataspec must contain exactly one track (two sides count as two tracks)";
 
-    usbSetDrive(spec.drive, false, F_INDEX_REAL);
+    usbSetDrive(spec.drive, false, F_INDEX_REAL, 6, 50, false);
 	usbSeek(spec.locations[0].track);
 
 	std::cout << "Measuring rotational speed...\n";

--- a/src/fe-rpm.cc
+++ b/src/fe-rpm.cc
@@ -23,7 +23,7 @@ int mainRpm(int argc, const char* argv[])
     flags.parseFlags(argc, argv);
 
     FluxSpec spec(source);
-    usbSetDrive(spec.drive, false, F_INDEX_REAL);
+    usbSetDrive(spec.drive, false, F_INDEX_REAL, 6, 50, false);
     nanoseconds_t period = usbGetRotationalPeriod(hardSectorCount);
     if (period != 0)
         std::cout << "Rotational period is " << period/1000000 << " ms (" << 60e9/period << " rpm)" << std::endl;

--- a/src/fe-seek.cc
+++ b/src/fe-seek.cc
@@ -17,11 +17,27 @@ static IntFlag track(
     "track to seek to",
     0);
 
+static BoolFlag doubleStep(
+    { "--double-step" },
+    "double-step 96tpi drives for 48tpi media",
+    false);
+
+static IntFlag stepIntervalTime(
+    { "--step-interval-time" },
+    "Head step interval time in milliseconds",
+    6);
+
+static IntFlag stepSettlingTime(
+    { "--step-settling-time" },
+    "Head step settling time in milliseconds",
+    50);
+
 int mainSeek(int argc, const char* argv[])
 {
     flags.parseFlags(argc, argv);
 
-    usbSetDrive(drive, false, F_INDEX_REAL);
+    usbSetDrive(drive, false, F_INDEX_REAL,
+        stepIntervalTime, stepSettlingTime, doubleStep);
     usbSeek(track);
     return 0;
 }


### PR DESCRIPTION
Some drives (like the Micropolis 1015-II require a step rate of 30ms, others, like 360K PC drives specify an 8ms step rate.  Add the ability to specify the step rate and settle time on command-line parameters.  Also allow the drive to be double-stepped (handy for reading 40-track disks in 80-track drives.)