### PR TITLE
Update fe-writeibm.cc

### DIFF
--- a/src/fe-writeibm.cc
+++ b/src/fe-writeibm.cc
@@ -141,7 +141,7 @@ static ActionFlag presetCBM1581(
 
 static ActionFlag presetHPLIF(
 	{ "--ibm-preset-hp-lif" },
-	"Preset parameters to a HP-LIF 3.5" 770kB HP disk.",
+	"Preset parameters to a HP-LIF 3.5\" 770kB HP disk.",
 	[] {
 		setWriterDefaultDest(":d=0:s=0-1:t=0-76");
 		setWriterDefaultInput(":c=77:h=2:s=5:b=1024");

--- a/src/fe-writeibm.cc
+++ b/src/fe-writeibm.cc
@@ -137,6 +137,29 @@ static ActionFlag presetCBM1581(
 		swapSides.setDefaultValue(true);
 	});
 
+/* --- HP-LIF ----------------------------------------------------- */
+
+static ActionFlag presetHPLIF(
+	{ "--ibm-preset-hp-lif" },
+	"Preset parameters to a HP-LIF 3.5" 770kB HP disk.",
+	[] {
+		setWriterDefaultDest(":d=0:s=0-1:t=0-76");
+		setWriterDefaultInput(":c=77:h=2:s=5:b=1024");
+		trackLengthMs.setDefaultValue(200);
+		sectorSize.setDefaultValue(1024);
+		startSectorId.setDefaultValue(1);
+		emitIam.setDefaultValue(true);
+		clockRateKhz.setDefaultValue(250);
+		idamByte.setDefaultValue(0x5554);
+		damByte.setDefaultValue(0x5545);
+		gap0.setDefaultValue(80);
+		gap1.setDefaultValue(50); //as emitIam is false this value remains unused
+		gap2.setDefaultValue(22);
+		gap3.setDefaultValue(44);
+		sectorSkew.setDefaultValue("01234");
+		swapSides.setDefaultValue(false);
+	});
+
 /* --- Atari ST disks ------------------------------------------------------ */
 
 static void set_atari_defaults()


### PR DESCRIPTION
Added a HP-LIF preset to write HP-LIF floppy disks for old HP analyzers in need of LIF formatted disks with 76 tracks and sectors of 1024 bytes.