### PR TITLE
add write support for various 5.25" formats

### DIFF
--- a/src/fe-writeibm.cc
+++ b/src/fe-writeibm.cc
@@ -116,6 +116,54 @@ static ActionFlag preset720(
 		set_ibm_defaults();
 	});
 
+static ActionFlag preset1200(
+	{ "--ibm-preset-1200" },
+	"Preset parameters to a PC 5.25\" 1.2MB disk.",
+	[] {
+		setWriterDefaultInput(":c=80:h=2:s=15:b=512");
+		setWriterDefaultDest(":t=0-79");
+		trackLengthMs.setDefaultValue(167);
+		clockRateKhz.setDefaultValue(500);
+		sectorSkew.setDefaultValue("0123456789abcde");
+		set_ibm_defaults();
+	});
+
+static ActionFlag preset720_qd(
+	{ "--ibm-preset-720-qd" },
+	"Preset parameters to a PC 5.25\" 720kB disk in a high-density drive.",
+	[] {
+		setWriterDefaultInput(":c=80:h=2:s=9:b=512");
+		setWriterDefaultDest(":t=0-79");
+		trackLengthMs.setDefaultValue(167);
+		clockRateKhz.setDefaultValue(300);
+		sectorSkew.setDefaultValue("012345678");
+		set_ibm_defaults();
+	});
+
+static ActionFlag preset360_hd(
+	{ "--ibm-preset-360-hd" },
+	"Preset parameters to a PC 5.25\" 360kB disk in a high-density drive.",
+	[] {
+		setWriterDefaultInput(":c=40:h=2:s=9:b=512");
+		setWriterDefaultDest(":t=0-79x2");
+		trackLengthMs.setDefaultValue(167);
+		clockRateKhz.setDefaultValue(300);
+		sectorSkew.setDefaultValue("012345678");
+		set_ibm_defaults();
+	});
+
+static ActionFlag preset360_dd(
+	{ "--ibm-preset-360-dd" },
+	"Preset parameters to a PC 5.25\" 360kB disk in a double-density drive.",
+	[] {
+		setWriterDefaultInput(":c=40:h=2:s=9:b=512");
+		setWriterDefaultDest(":t=0-39");
+		trackLengthMs.setDefaultValue(200);
+		clockRateKhz.setDefaultValue(250);
+		sectorSkew.setDefaultValue("012345678");
+		set_ibm_defaults();
+	});
+
 /* --- Commodore disks ----------------------------------------------------- */
 
 static ActionFlag presetCBM1581(


### PR DESCRIPTION
I wanted to create a FreeDOS boot floppy for an old Pentium III motherboard I had recently salvaged, but had the Teac FD-55GFR I'd bought 30 years ago for my first x86 box and some double-density floppies purchased NIB from an eBay seller.  (My longer-term interest in the FluxEngine is interoperation with the Apple II, but I'm just getting started with it.)  I'm not sure if there's a command-line incantation that sets up all the options just right to write 5.25" floppies, but this PR adds some presets for the common formats.  Separate options handle writing 360K disks in either double-density or high-density drives, and I included a 720K "quad-density" option (80 double-density tracks per side written in a high-density drive) that I used for cheap backups back in the day.  

So far, I've tested writing both 360K and 720K formats in a high-density drive, and I've booted FreeDOS from the 360K disk when the drive was hooked up to another system.  I have a double-density drive on order from another eBay seller and should probably snag some high-density disks as well to test that, but I suspect you can tell by looking at the source if I have the options right.