### PR TITLE
Make the Windows build static again.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: msys2/setup-msys2@v2
       with:
-        update: false
+        update: true
         msystem: MINGW32
         install: >-
           make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: msys2/setup-msys2@v2
       with:
-        update: false
+        update: true
         msystem: MINGW32
         install: >-
           make

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ export AR = /mingw32/bin/ar rcs
 export STRIP = /mingw32/bin/strip
 export CFLAGS += -I/mingw32/include/libusb-1.0 -I/mingw32/include
 export LDFLAGS +=
-export LIBS += -L/mingw32/lib -lz -lsqlite3 -lusb-1.0 -lprotobuf
+export LIBS += -L/mingw32/lib -static -lz -lsqlite3 -lusb-1.0 -lprotobuf
 export EXTENSION = .exe
 else
 


### PR DESCRIPTION
It turns out I'd managed to leave out -static, producing dynamic binaries that didn't work without all the additional libraries being installed.

Fixes: #265 