### PR TITLE
Refactor the decoders

### DIFF
--- a/arch/aeslanier/aeslanier.h
+++ b/arch/aeslanier/aeslanier.h
@@ -19,4 +19,6 @@ public:
     void decodeSectorRecord();
 };
 
+extern std::unique_ptr<AbstractDecoder> createAesLanierDecoder(const DecoderProto& config);
+
 #endif

--- a/arch/aeslanier/aeslanier.h
+++ b/arch/aeslanier/aeslanier.h
@@ -5,20 +5,6 @@
 #define AESLANIER_SECTOR_LENGTH    256
 #define AESLANIER_RECORD_SIZE      (AESLANIER_SECTOR_LENGTH + 5)
 
-class Sector;
-class Fluxmap;
-class AesLanierDecoderProto;
-
-class AesLanierDecoder : public AbstractDecoder
-{
-public:
-	AesLanierDecoder(const AesLanierDecoderProto&) {}
-    virtual ~AesLanierDecoder() {}
-
-    RecordType advanceToNextRecord();
-    void decodeSectorRecord();
-};
-
 extern std::unique_ptr<AbstractDecoder> createAesLanierDecoder(const DecoderProto& config);
 
 #endif

--- a/arch/amiga/amiga.h
+++ b/arch/amiga/amiga.h
@@ -15,18 +15,6 @@ class SectorSet;
 class AmigaDecoderProto;
 class AmigaEncoderProto;
 
-class AmigaDecoder : public AbstractDecoder
-{
-public:
-	AmigaDecoder(const AmigaDecoderProto&) {}
-    virtual ~AmigaDecoder() {}
-
-    RecordType advanceToNextRecord();
-    void decodeSectorRecord();
-
-	std::set<unsigned> requiredSectors(Track& track) const;
-};
-
 class AmigaEncoder : public AbstractEncoder
 {
 public:
@@ -40,6 +28,8 @@ public:
 private:
 	const AmigaEncoderProto& _config;
 };
+
+extern std::unique_ptr<AbstractDecoder> createAmigaDecoder(const DecoderProto& config);
 
 extern uint32_t amigaChecksum(const Bytes& bytes);
 extern Bytes amigaInterleave(const Bytes& input);

--- a/arch/amiga/decoder.cc
+++ b/arch/amiga/decoder.cc
@@ -8,6 +8,7 @@
 #include "amiga.h"
 #include "bytes.h"
 #include "fmt/format.h"
+#include "lib/decoders/decoders.pb.h"
 #include <string.h>
 #include <algorithm>
 
@@ -21,47 +22,64 @@
          
 static const FluxPattern SECTOR_PATTERN(48, AMIGA_SECTOR_RECORD);
 
-AbstractDecoder::RecordType AmigaDecoder::advanceToNextRecord()
+class AmigaDecoder : public AbstractDecoder
 {
-    _sector->clock = _fmr->seekToPattern(SECTOR_PATTERN);
-    if (_fmr->eof() || !_sector->clock)
-        return UNKNOWN_RECORD;
-    return SECTOR_RECORD;
-}
+public:
+	AmigaDecoder(const DecoderProto& config):
+		AbstractDecoder(config),
+		_config(config.amiga())
+	{}
 
-void AmigaDecoder::decodeSectorRecord()
+    RecordType advanceToNextRecord()
+	{
+		_sector->clock = _fmr->seekToPattern(SECTOR_PATTERN);
+		if (_fmr->eof() || !_sector->clock)
+			return UNKNOWN_RECORD;
+		return SECTOR_RECORD;
+	}
+
+    void decodeSectorRecord()
+	{
+		const auto& rawbits = readRawBits(AMIGA_RECORD_SIZE*16);
+		if (rawbits.size() < (AMIGA_RECORD_SIZE*16))
+			return;
+		const auto& rawbytes = toBytes(rawbits).slice(0, AMIGA_RECORD_SIZE*2);
+		const auto& bytes = decodeFmMfm(rawbits).slice(0, AMIGA_RECORD_SIZE);
+
+		const uint8_t* ptr = bytes.begin() + 3;
+
+		Bytes header = amigaDeinterleave(ptr, 4);
+		Bytes recoveryinfo = amigaDeinterleave(ptr, 16);
+
+		_sector->logicalTrack = header[1] >> 1;
+		_sector->logicalSide = header[1] & 1;
+		_sector->logicalSector = header[2];
+
+		uint32_t wantedheaderchecksum = amigaDeinterleave(ptr, 4).reader().read_be32();
+		uint32_t gotheaderchecksum = amigaChecksum(rawbytes.slice(6, 40));
+		if (gotheaderchecksum != wantedheaderchecksum)
+			return;
+
+		uint32_t wanteddatachecksum = amigaDeinterleave(ptr, 4).reader().read_be32();
+		uint32_t gotdatachecksum = amigaChecksum(rawbytes.slice(62, 1024));
+
+		_sector->data.clear();
+		_sector->data.writer().append(amigaDeinterleave(ptr, 512)).append(recoveryinfo);
+		_sector->status = (gotdatachecksum == wanteddatachecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
+	}
+
+	std::set<unsigned> requiredSectors(Track& track) const
+	{
+		static std::set<unsigned> sectors = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+		return sectors;
+	}
+
+private:
+	const AmigaDecoderProto& _config;
+};
+
+std::unique_ptr<AbstractDecoder> createAmigaDecoder(const DecoderProto& config)
 {
-    const auto& rawbits = readRawBits(AMIGA_RECORD_SIZE*16);
-	if (rawbits.size() < (AMIGA_RECORD_SIZE*16))
-		return;
-    const auto& rawbytes = toBytes(rawbits).slice(0, AMIGA_RECORD_SIZE*2);
-    const auto& bytes = decodeFmMfm(rawbits).slice(0, AMIGA_RECORD_SIZE);
-
-    const uint8_t* ptr = bytes.begin() + 3;
-
-    Bytes header = amigaDeinterleave(ptr, 4);
-    Bytes recoveryinfo = amigaDeinterleave(ptr, 16);
-
-    _sector->logicalTrack = header[1] >> 1;
-    _sector->logicalSide = header[1] & 1;
-    _sector->logicalSector = header[2];
-
-    uint32_t wantedheaderchecksum = amigaDeinterleave(ptr, 4).reader().read_be32();
-    uint32_t gotheaderchecksum = amigaChecksum(rawbytes.slice(6, 40));
-    if (gotheaderchecksum != wantedheaderchecksum)
-        return;
-
-    uint32_t wanteddatachecksum = amigaDeinterleave(ptr, 4).reader().read_be32();
-    uint32_t gotdatachecksum = amigaChecksum(rawbytes.slice(62, 1024));
-
-    _sector->data.clear();
-    _sector->data.writer().append(amigaDeinterleave(ptr, 512)).append(recoveryinfo);
-    _sector->status = (gotdatachecksum == wanteddatachecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
-}
-
-std::set<unsigned> AmigaDecoder::requiredSectors(Track& track) const
-{
-	static std::set<unsigned> sectors = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-	return sectors;
+	return std::unique_ptr<AbstractDecoder>(new AmigaDecoder(config));
 }
 

--- a/arch/apple2/apple2.h
+++ b/arch/apple2/apple2.h
@@ -7,21 +7,6 @@
 #define APPLE2_SECTOR_LENGTH   256
 #define APPLE2_ENCODED_SECTOR_LENGTH 342
 
-class Sector;
-class Fluxmap;
-class Apple2DecoderProto;
-
-class Apple2Decoder : public AbstractDecoder
-{
-public:
-	Apple2Decoder(const Apple2DecoderProto&) {}
-    virtual ~Apple2Decoder() {}
-
-    RecordType advanceToNextRecord();
-    void decodeSectorRecord();
-    void decodeDataRecord();
-};
-
 extern std::unique_ptr<AbstractDecoder> createApple2Decoder(const DecoderProto& config);
 
 #endif

--- a/arch/apple2/apple2.h
+++ b/arch/apple2/apple2.h
@@ -22,6 +22,7 @@ public:
     void decodeDataRecord();
 };
 
+extern std::unique_ptr<AbstractDecoder> createApple2Decoder(const DecoderProto& config);
 
 #endif
 

--- a/arch/brother/brother.h
+++ b/arch/brother/brother.h
@@ -46,4 +46,6 @@ public:
     std::unique_ptr<Fluxmap> encode(int physicalTrack, int physicalSide, const SectorSet& allSectors);
 };
 
+extern std::unique_ptr<AbstractDecoder> createBrotherDecoder(const DecoderProto& config);
+
 #endif

--- a/arch/brother/brother.h
+++ b/arch/brother/brother.h
@@ -19,17 +19,6 @@ class Fluxmap;
 class BrotherDecoderProto;
 class BrotherEncoderProto;
 
-class BrotherDecoder : public AbstractDecoder
-{
-public:
-    BrotherDecoder(const BrotherDecoderProto& config) {}
-    virtual ~BrotherDecoder() {}
-
-    RecordType advanceToNextRecord();
-    void decodeSectorRecord();
-    void decodeDataRecord();
-};
-
 class BrotherEncoder : public AbstractEncoder
 {
 public:

--- a/arch/c64/c64.h
+++ b/arch/c64/c64.h
@@ -65,4 +65,6 @@ private:
 	uint8_t _formatByte2;
 };
 
+extern std::unique_ptr<AbstractDecoder> createCommodore64Decoder(const DecoderProto& config);
+
 #endif

--- a/arch/c64/c64.h
+++ b/arch/c64/c64.h
@@ -33,17 +33,6 @@ class Fluxmap;
 class Commodore64DecoderProto;
 class Commodore64EncoderProto;
 
-class Commodore64Decoder : public AbstractDecoder
-{
-public:
-	Commodore64Decoder(const Commodore64DecoderProto&) {}
-    virtual ~Commodore64Decoder() {}
-
-    RecordType advanceToNextRecord();
-    void decodeSectorRecord();
-    void decodeDataRecord();
-};
-
 class Commodore64Encoder : public AbstractEncoder
 {
 public:

--- a/arch/c64/decoder.cc
+++ b/arch/c64/decoder.cc
@@ -52,41 +52,56 @@ static Bytes decode(const std::vector<bool>& bits)
     return output;
 }
 
-AbstractDecoder::RecordType Commodore64Decoder::advanceToNextRecord()
+class Commodore64Decoder : public AbstractDecoder
 {
-	const FluxMatcher* matcher = nullptr;
-	_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
-	if (matcher == &SECTOR_RECORD_PATTERN)
-		return RecordType::SECTOR_RECORD;
-	if (matcher == &DATA_RECORD_PATTERN)
-		return RecordType::DATA_RECORD;
-	return RecordType::UNKNOWN_RECORD;
+public:
+	Commodore64Decoder(const DecoderProto& config):
+		AbstractDecoder(config)
+	{}
+
+    RecordType advanceToNextRecord()
+	{
+		const FluxMatcher* matcher = nullptr;
+		_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
+		if (matcher == &SECTOR_RECORD_PATTERN)
+			return RecordType::SECTOR_RECORD;
+		if (matcher == &DATA_RECORD_PATTERN)
+			return RecordType::DATA_RECORD;
+		return RecordType::UNKNOWN_RECORD;
+	}
+
+    void decodeSectorRecord()
+	{
+		readRawBits(20);
+
+		const auto& bits = readRawBits(5*10);
+		const auto& bytes = decode(bits).slice(0, 5);
+
+		uint8_t checksum = bytes[0];
+		_sector->logicalSector = bytes[1];
+		_sector->logicalSide = 0;
+		_sector->logicalTrack = bytes[2] - 1;
+		if (checksum == xorBytes(bytes.slice(1, 4)))
+			_sector->status = Sector::DATA_MISSING; /* unintuitive but correct */
+	}
+
+    void decodeDataRecord()
+	{
+		readRawBits(20);
+
+		const auto& bits = readRawBits(259*10);
+		const auto& bytes = decode(bits).slice(0, 259);
+
+		_sector->data = bytes.slice(0, C64_SECTOR_LENGTH);
+		uint8_t gotChecksum = xorBytes(_sector->data);
+		uint8_t wantChecksum = bytes[256];
+		_sector->status = (wantChecksum == gotChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
+	}
+};
+
+std::unique_ptr<AbstractDecoder> createCommodore64Decoder(const DecoderProto& config)
+{
+	return std::unique_ptr<AbstractDecoder>(new Commodore64Decoder(config));
 }
 
-void Commodore64Decoder::decodeSectorRecord()
-{
-    readRawBits(20);
 
-    const auto& bits = readRawBits(5*10);
-    const auto& bytes = decode(bits).slice(0, 5);
-
-    uint8_t checksum = bytes[0];
-    _sector->logicalSector = bytes[1];
-    _sector->logicalSide = 0;
-    _sector->logicalTrack = bytes[2] - 1;
-    if (checksum == xorBytes(bytes.slice(1, 4)))
-        _sector->status = Sector::DATA_MISSING; /* unintuitive but correct */
-}
-
-void Commodore64Decoder::decodeDataRecord()
-{
-    readRawBits(20);
-
-    const auto& bits = readRawBits(259*10);
-    const auto& bytes = decode(bits).slice(0, 259);
-
-    _sector->data = bytes.slice(0, C64_SECTOR_LENGTH);
-    uint8_t gotChecksum = xorBytes(_sector->data);
-    uint8_t wantChecksum = bytes[256];
-    _sector->status = (wantChecksum == gotChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
-}

--- a/arch/f85/decoder.cc
+++ b/arch/f85/decoder.cc
@@ -52,49 +52,63 @@ static Bytes decode(const std::vector<bool>& bits)
     return output;
 }
 
-AbstractDecoder::RecordType DurangoF85Decoder::advanceToNextRecord()
+class DurangoF85Decoder : public AbstractDecoder
 {
-	const FluxMatcher* matcher = nullptr;
-	_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
-	if (matcher == &SECTOR_RECORD_PATTERN)
-		return RecordType::SECTOR_RECORD;
-	if (matcher == &DATA_RECORD_PATTERN)
-		return RecordType::DATA_RECORD;
-	return RecordType::UNKNOWN_RECORD;
+public:
+	DurangoF85Decoder(const DecoderProto& config):
+		AbstractDecoder(config)
+	{}
+
+    RecordType advanceToNextRecord()
+	{
+		const FluxMatcher* matcher = nullptr;
+		_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
+		if (matcher == &SECTOR_RECORD_PATTERN)
+			return RecordType::SECTOR_RECORD;
+		if (matcher == &DATA_RECORD_PATTERN)
+			return RecordType::DATA_RECORD;
+		return RecordType::UNKNOWN_RECORD;
+	}
+
+    void decodeSectorRecord()
+	{
+		/* Skip sync bits and ID byte. */
+
+		readRawBits(24);
+
+		/* Read header. */
+
+		const auto& bytes = decode(readRawBits(6*10));
+
+		_sector->logicalSector = bytes[2];
+		_sector->logicalSide = 0;
+		_sector->logicalTrack = bytes[0];
+
+		uint16_t wantChecksum = bytes.reader().seek(4).read_be16();
+		uint16_t gotChecksum = crc16(CCITT_POLY, 0xef21, bytes.slice(0, 4));
+		if (wantChecksum == gotChecksum)
+			_sector->status = Sector::DATA_MISSING; /* unintuitive but correct */
+	}
+
+    void decodeDataRecord()
+	{
+		/* Skip sync bits ID byte. */
+
+		readRawBits(24);
+
+		const auto& bytes = decode(readRawBits((F85_SECTOR_LENGTH+3)*10))
+			.slice(0, F85_SECTOR_LENGTH+3);
+		ByteReader br(bytes);
+
+		_sector->data = br.read(F85_SECTOR_LENGTH);
+		uint16_t wantChecksum = br.read_be16();
+		uint16_t gotChecksum = crc16(CCITT_POLY, 0xbf84, _sector->data);
+		_sector->status = (wantChecksum == gotChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
+	}
+};
+
+std::unique_ptr<AbstractDecoder> createDurangoF85Decoder(const DecoderProto& config)
+{
+	return std::unique_ptr<AbstractDecoder>(new DurangoF85Decoder(config));
 }
 
-void DurangoF85Decoder::decodeSectorRecord()
-{
-    /* Skip sync bits and ID byte. */
-
-    readRawBits(24);
-
-    /* Read header. */
-
-    const auto& bytes = decode(readRawBits(6*10));
-
-    _sector->logicalSector = bytes[2];
-    _sector->logicalSide = 0;
-    _sector->logicalTrack = bytes[0];
-
-    uint16_t wantChecksum = bytes.reader().seek(4).read_be16();
-    uint16_t gotChecksum = crc16(CCITT_POLY, 0xef21, bytes.slice(0, 4));
-    if (wantChecksum == gotChecksum)
-        _sector->status = Sector::DATA_MISSING; /* unintuitive but correct */
-}
-
-void DurangoF85Decoder::decodeDataRecord()
-{
-    /* Skip sync bits ID byte. */
-
-    readRawBits(24);
-
-    const auto& bytes = decode(readRawBits((F85_SECTOR_LENGTH+3)*10))
-        .slice(0, F85_SECTOR_LENGTH+3);
-    ByteReader br(bytes);
-
-    _sector->data = br.read(F85_SECTOR_LENGTH);
-    uint16_t wantChecksum = br.read_be16();
-    uint16_t gotChecksum = crc16(CCITT_POLY, 0xbf84, _sector->data);
-    _sector->status = (wantChecksum == gotChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
-}

--- a/arch/f85/f85.h
+++ b/arch/f85/f85.h
@@ -20,4 +20,6 @@ public:
     void decodeDataRecord();
 };
 
+extern std::unique_ptr<AbstractDecoder> createDurangoF85Decoder(const DecoderProto& config);
+
 #endif

--- a/arch/f85/f85.h
+++ b/arch/f85/f85.h
@@ -5,21 +5,6 @@
 #define F85_DATA_RECORD 0xffffcb /* 1111 1111 1111 1111 1100 1101 */
 #define F85_SECTOR_LENGTH    512
 
-class Sector;
-class Fluxmap;
-class F85DecoderProto;
-
-class DurangoF85Decoder : public AbstractDecoder
-{
-public:
-	DurangoF85Decoder(const F85DecoderProto&) {}
-    virtual ~DurangoF85Decoder() {}
-
-    RecordType advanceToNextRecord();
-    void decodeSectorRecord();
-    void decodeDataRecord();
-};
-
 extern std::unique_ptr<AbstractDecoder> createDurangoF85Decoder(const DecoderProto& config);
 
 #endif

--- a/arch/fb100/decoder.cc
+++ b/arch/fb100/decoder.cc
@@ -99,37 +99,52 @@ static uint16_t checksum(const Bytes& bytes)
     return (crchi << 8) | crclo;
 }
 
-AbstractDecoder::RecordType Fb100Decoder::advanceToNextRecord()
+class Fb100Decoder : public AbstractDecoder
 {
-	const FluxMatcher* matcher = nullptr;
-	_sector->clock = _fmr->seekToPattern(SECTOR_ID_PATTERN, matcher);
-    if (matcher == &SECTOR_ID_PATTERN)
-		return RecordType::SECTOR_RECORD;
-	return RecordType::UNKNOWN_RECORD;
+public:
+	Fb100Decoder(const DecoderProto& config):
+		AbstractDecoder(config)
+	{}
+
+    RecordType advanceToNextRecord()
+	{
+		const FluxMatcher* matcher = nullptr;
+		_sector->clock = _fmr->seekToPattern(SECTOR_ID_PATTERN, matcher);
+		if (matcher == &SECTOR_ID_PATTERN)
+			return RecordType::SECTOR_RECORD;
+		return RecordType::UNKNOWN_RECORD;
+	}
+
+    void decodeSectorRecord()
+	{
+		auto rawbits = readRawBits(FB100_RECORD_SIZE*16);
+
+		const Bytes bytes = decodeFmMfm(rawbits).slice(0, FB100_RECORD_SIZE);
+		ByteReader br(bytes);
+		br.seek(1);
+		const Bytes id = br.read(FB100_ID_SIZE);
+		uint16_t wantIdCrc = br.read_be16();
+		uint16_t gotIdCrc = checksum(id);
+		const Bytes payload = br.read(FB100_PAYLOAD_SIZE);
+		uint16_t wantPayloadCrc = br.read_be16();
+		uint16_t gotPayloadCrc = checksum(payload);
+
+		if (wantIdCrc != gotIdCrc)
+			return;
+
+		uint8_t abssector = id[2];
+		_sector->logicalTrack = abssector >> 1;
+		_sector->logicalSide = 0;
+		_sector->logicalSector = abssector & 1;
+		_sector->data.writer().append(id.slice(5, 12)).append(payload);
+
+		_sector->status = (wantPayloadCrc == gotPayloadCrc) ? Sector::OK : Sector::BAD_CHECKSUM;
+	}
+};
+
+std::unique_ptr<AbstractDecoder> createFb100Decoder(const DecoderProto& config)
+{
+	return std::unique_ptr<AbstractDecoder>(new Fb100Decoder(config));
 }
 
-void Fb100Decoder::decodeSectorRecord()
-{
-    auto rawbits = readRawBits(FB100_RECORD_SIZE*16);
 
-    const Bytes bytes = decodeFmMfm(rawbits).slice(0, FB100_RECORD_SIZE);
-    ByteReader br(bytes);
-    br.seek(1);
-    const Bytes id = br.read(FB100_ID_SIZE);
-    uint16_t wantIdCrc = br.read_be16();
-    uint16_t gotIdCrc = checksum(id);
-    const Bytes payload = br.read(FB100_PAYLOAD_SIZE);
-    uint16_t wantPayloadCrc = br.read_be16();
-    uint16_t gotPayloadCrc = checksum(payload);
-
-    if (wantIdCrc != gotIdCrc)
-        return;
-
-    uint8_t abssector = id[2];
-    _sector->logicalTrack = abssector >> 1;
-    _sector->logicalSide = 0;
-    _sector->logicalSector = abssector & 1;
-    _sector->data.writer().append(id.slice(5, 12)).append(payload);
-
-    _sector->status = (wantPayloadCrc == gotPayloadCrc) ? Sector::OK : Sector::BAD_CHECKSUM;
-}

--- a/arch/fb100/fb100.h
+++ b/arch/fb100/fb100.h
@@ -20,5 +20,7 @@ public:
     void decodeSectorRecord();
 };
 
+extern std::unique_ptr<AbstractDecoder> createFb100Decoder(const DecoderProto& config);
+
 #endif
 

--- a/arch/fb100/fb100.h
+++ b/arch/fb100/fb100.h
@@ -5,21 +5,6 @@
 #define FB100_ID_SIZE 17
 #define FB100_PAYLOAD_SIZE 0x500
 
-class Sector;
-class Fluxmap;
-class Track;
-class Fb100DecoderProto;
-
-class Fb100Decoder : public AbstractDecoder
-{
-public:
-	Fb100Decoder(const Fb100DecoderProto&) {}
-    virtual ~Fb100Decoder() {}
-
-    RecordType advanceToNextRecord();
-    void decodeSectorRecord();
-};
-
 extern std::unique_ptr<AbstractDecoder> createFb100Decoder(const DecoderProto& config);
 
 #endif

--- a/arch/ibm/decoder.cc
+++ b/arch/ibm/decoder.cc
@@ -184,5 +184,3 @@ std::unique_ptr<AbstractDecoder> createIbmDecoder(const DecoderProto& config)
 	return std::unique_ptr<AbstractDecoder>(new IbmDecoder(config));
 }
 
-
-

--- a/arch/ibm/decoder.cc
+++ b/arch/ibm/decoder.cc
@@ -91,76 +91,98 @@ const FluxMatchers ANY_RECORD_PATTERN(
     }
 );
 
-std::set<unsigned> IbmDecoder::requiredSectors(Track& track) const
+class IbmDecoder : public AbstractDecoder
 {
-	return iterate(_config.required_sectors());
+public:
+    IbmDecoder(const DecoderProto& config):
+		AbstractDecoder(config),
+		_config(config.ibm())
+    {}
+
+    RecordType advanceToNextRecord()
+	{
+		const FluxMatcher* matcher = nullptr;
+		_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
+
+		/* If this is the MFM prefix byte, the the decoder is going to expect three
+		 * extra bytes on the front of the header. */
+		_currentHeaderLength = (matcher == &MFM_PATTERN) ? 3 : 0;
+
+		Fluxmap::Position here = tell();
+		if (_currentHeaderLength > 0)
+			readRawBits(_currentHeaderLength*16);
+		auto idbits = readRawBits(16);
+		const Bytes idbytes = decodeFmMfm(idbits);
+		uint8_t id = idbytes.slice(0, 1)[0];
+		seek(here);
+		
+		switch (id)
+		{
+			case IBM_IDAM:
+				return RecordType::SECTOR_RECORD;
+
+			case IBM_DAM1:
+			case IBM_DAM2:
+			case IBM_TRS80DAM1:
+			case IBM_TRS80DAM2:
+				return RecordType::DATA_RECORD;
+		}
+		return RecordType::UNKNOWN_RECORD;
+	}
+
+    void decodeSectorRecord()
+	{
+		unsigned recordSize = _currentHeaderLength + IBM_IDAM_LEN;
+		auto bits = readRawBits(recordSize*16);
+		auto bytes = decodeFmMfm(bits).slice(0, recordSize);
+
+		ByteReader br(bytes);
+		br.seek(_currentHeaderLength);
+		br.read_8(); /* skip ID byte */
+		_sector->logicalTrack = br.read_8();
+		_sector->logicalSide = br.read_8();
+		_sector->logicalSector = br.read_8() - _config.sector_id_base();
+		_currentSectorSize = 1 << (br.read_8() + 7);
+		uint16_t wantCrc = br.read_be16();
+		uint16_t gotCrc = crc16(CCITT_POLY, bytes.slice(0, _currentHeaderLength + 5));
+		if (wantCrc == gotCrc)
+			_sector->status = Sector::DATA_MISSING; /* correct but unintuitive */
+
+		if (_config.ignore_side_byte())
+			_sector->logicalSide = _sector->physicalSide;
+	}
+
+    void decodeDataRecord()
+	{
+		unsigned recordLength = _currentHeaderLength + _currentSectorSize + 3;
+		auto bits = readRawBits(recordLength*16);
+		auto bytes = decodeFmMfm(bits).slice(0, recordLength);
+
+		ByteReader br(bytes);
+		br.seek(_currentHeaderLength);
+		br.read_8(); /* skip ID byte */
+
+		_sector->data = br.read(_currentSectorSize);
+		uint16_t wantCrc = br.read_be16();
+		uint16_t gotCrc = crc16(CCITT_POLY, bytes.slice(0, recordLength-2));
+		_sector->status = (wantCrc == gotCrc) ? Sector::OK : Sector::BAD_CHECKSUM;
+	}
+
+	std::set<unsigned> requiredSectors(Track& track) const
+	{
+		return iterate(_config.required_sectors());
+	}
+
+private:
+	const IbmDecoderProto& _config;
+    unsigned _currentSectorSize;
+    unsigned _currentHeaderLength;
+};
+
+std::unique_ptr<AbstractDecoder> createIbmDecoder(const DecoderProto& config)
+{
+	return std::unique_ptr<AbstractDecoder>(new IbmDecoder(config));
 }
 
-AbstractDecoder::RecordType IbmDecoder::advanceToNextRecord()
-{
-	const FluxMatcher* matcher = nullptr;
-	_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
 
-    /* If this is the MFM prefix byte, the the decoder is going to expect three
-     * extra bytes on the front of the header. */
-    _currentHeaderLength = (matcher == &MFM_PATTERN) ? 3 : 0;
 
-    Fluxmap::Position here = tell();
-    if (_currentHeaderLength > 0)
-        readRawBits(_currentHeaderLength*16);
-    auto idbits = readRawBits(16);
-    const Bytes idbytes = decodeFmMfm(idbits);
-    uint8_t id = idbytes.slice(0, 1)[0];
-    seek(here);
-    
-    switch (id)
-    {
-        case IBM_IDAM:
-            return RecordType::SECTOR_RECORD;
-
-        case IBM_DAM1:
-        case IBM_DAM2:
-        case IBM_TRS80DAM1:
-        case IBM_TRS80DAM2:
-            return RecordType::DATA_RECORD;
-    }
-    return RecordType::UNKNOWN_RECORD;
-}
-
-void IbmDecoder::decodeSectorRecord()
-{
-    unsigned recordSize = _currentHeaderLength + IBM_IDAM_LEN;
-    auto bits = readRawBits(recordSize*16);
-    auto bytes = decodeFmMfm(bits).slice(0, recordSize);
-
-    ByteReader br(bytes);
-    br.seek(_currentHeaderLength);
-    br.read_8(); /* skip ID byte */
-    _sector->logicalTrack = br.read_8();
-    _sector->logicalSide = br.read_8();
-    _sector->logicalSector = br.read_8() - _config.sector_id_base();
-    _currentSectorSize = 1 << (br.read_8() + 7);
-    uint16_t wantCrc = br.read_be16();
-    uint16_t gotCrc = crc16(CCITT_POLY, bytes.slice(0, _currentHeaderLength + 5));
-    if (wantCrc == gotCrc)
-        _sector->status = Sector::DATA_MISSING; /* correct but unintuitive */
-
-    if (_config.ignore_side_byte())
-        _sector->logicalSide = _sector->physicalSide;
-}
-
-void IbmDecoder::decodeDataRecord()
-{
-    unsigned recordLength = _currentHeaderLength + _currentSectorSize + 3;
-    auto bits = readRawBits(recordLength*16);
-    auto bytes = decodeFmMfm(bits).slice(0, recordLength);
-
-    ByteReader br(bytes);
-    br.seek(_currentHeaderLength);
-    br.read_8(); /* skip ID byte */
-
-    _sector->data = br.read(_currentSectorSize);
-    uint16_t wantCrc = br.read_be16();
-    uint16_t gotCrc = crc16(CCITT_POLY, bytes.slice(0, recordLength-2));
-    _sector->status = (wantCrc == gotCrc) ? Sector::OK : Sector::BAD_CHECKSUM;
-}

--- a/arch/ibm/ibm.h
+++ b/arch/ibm/ibm.h
@@ -74,4 +74,6 @@ private:
 	bool _lastBit;
 };
 
+extern std::unique_ptr<AbstractDecoder> createIbmDecoder(const DecoderProto& config);
+
 #endif

--- a/arch/ibm/ibm.h
+++ b/arch/ibm/ibm.h
@@ -30,25 +30,6 @@ struct IbmIdam
     uint8_t crc[2];
 };
 
-class IbmDecoder : public AbstractDecoder
-{
-public:
-    IbmDecoder(const IbmDecoderProto& config):
-		_config(config)
-    {}
-
-    RecordType advanceToNextRecord();
-    void decodeSectorRecord();
-    void decodeDataRecord();
-
-	std::set<unsigned> requiredSectors(Track& track) const;
-
-private:
-	const IbmDecoderProto& _config;
-    unsigned _currentSectorSize;
-    unsigned _currentHeaderLength;
-};
-
 class IbmEncoder : public AbstractEncoder
 {
 public:

--- a/arch/macintosh/decoder.cc
+++ b/arch/macintosh/decoder.cc
@@ -124,85 +124,98 @@ uint8_t decode_side(uint8_t side)
     return !!(side & 0x20);
 }
 
-AbstractDecoder::RecordType MacintoshDecoder::advanceToNextRecord()
+class MacintoshDecoder : public AbstractDecoder
 {
-	const FluxMatcher* matcher = nullptr;
-	_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
-	if (matcher == &SECTOR_RECORD_PATTERN)
-		return SECTOR_RECORD;
-	if (matcher == &DATA_RECORD_PATTERN)
-		return DATA_RECORD;
-	return UNKNOWN_RECORD;
-}
+public:
+	MacintoshDecoder(const DecoderProto& config):
+		AbstractDecoder(config)
+	{}
 
-void MacintoshDecoder::decodeSectorRecord()
+    RecordType advanceToNextRecord()
+	{
+		const FluxMatcher* matcher = nullptr;
+		_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
+		if (matcher == &SECTOR_RECORD_PATTERN)
+			return SECTOR_RECORD;
+		if (matcher == &DATA_RECORD_PATTERN)
+			return DATA_RECORD;
+		return UNKNOWN_RECORD;
+	}
+
+    void decodeSectorRecord()
+	{
+		/* Skip ID (as we know it's a MAC_SECTOR_RECORD). */
+		readRawBits(24);
+
+		/* Read header. */
+
+		auto header = toBytes(readRawBits(7*8)).slice(0, 7);
+					
+		uint8_t encodedTrack = decode_data_gcr(header[0]);
+		if (encodedTrack != (_track->physicalTrack & 0x3f))
+			return;
+					
+		uint8_t encodedSector = decode_data_gcr(header[1]);
+		uint8_t encodedSide = decode_data_gcr(header[2]);
+		uint8_t formatByte = decode_data_gcr(header[3]);
+		uint8_t wantedsum = decode_data_gcr(header[4]);
+
+		if (encodedSector > 11)
+			return;
+
+		_sector->logicalTrack = _track->physicalTrack;
+		_sector->logicalSide = decode_side(encodedSide);
+		_sector->logicalSector = encodedSector;
+		uint8_t gotsum = (encodedTrack ^ encodedSector ^ encodedSide ^ formatByte) & 0x3f;
+		if (wantedsum == gotsum)
+			_sector->status = Sector::DATA_MISSING; /* unintuitive but correct */
+	}
+
+    void decodeDataRecord()
+	{
+		auto id = toBytes(readRawBits(24)).reader().read_be24();
+		if (id != MAC_DATA_RECORD)
+			return;
+
+		/* Read data. */
+
+		readRawBits(8); /* skip spare byte */
+		auto inputbuffer = toBytes(readRawBits(MAC_ENCODED_SECTOR_LENGTH*8))
+			.slice(0, MAC_ENCODED_SECTOR_LENGTH);
+
+		for (unsigned i=0; i<inputbuffer.size(); i++)
+			inputbuffer[i] = decode_data_gcr(inputbuffer[i]);
+			
+		_sector->status = Sector::BAD_CHECKSUM;
+		Bytes userData = decode_crazy_data(inputbuffer, _sector->status);
+		_sector->data.clear();
+		_sector->data.writer().append(userData.slice(12, 512)).append(userData.slice(0, 12));
+	}
+
+	std::set<unsigned> requiredSectors(Track& track) const
+	{
+		int count;
+		if (track.physicalTrack < 16)
+			count = 12;
+		else if (track.physicalTrack < 32)
+			count = 11;
+		else if (track.physicalTrack < 48)
+			count = 10;
+		else if (track.physicalTrack < 64)
+			count = 9;
+		else
+			count = 8;
+
+		std::set<unsigned> sectors;
+		while (count--)
+			sectors.insert(count);
+		return sectors;
+	}
+};
+
+std::unique_ptr<AbstractDecoder> createMacintoshDecoder(const DecoderProto& config)
 {
-    /* Skip ID (as we know it's a MAC_SECTOR_RECORD). */
-    readRawBits(24);
-
-    /* Read header. */
-
-    auto header = toBytes(readRawBits(7*8)).slice(0, 7);
-                
-    uint8_t encodedTrack = decode_data_gcr(header[0]);
-    if (encodedTrack != (_track->physicalTrack & 0x3f))
-        return;
-                
-    uint8_t encodedSector = decode_data_gcr(header[1]);
-    uint8_t encodedSide = decode_data_gcr(header[2]);
-    uint8_t formatByte = decode_data_gcr(header[3]);
-    uint8_t wantedsum = decode_data_gcr(header[4]);
-
-    if (encodedSector > 11)
-        return;
-
-    _sector->logicalTrack = _track->physicalTrack;
-    _sector->logicalSide = decode_side(encodedSide);
-    _sector->logicalSector = encodedSector;
-    uint8_t gotsum = (encodedTrack ^ encodedSector ^ encodedSide ^ formatByte) & 0x3f;
-    if (wantedsum == gotsum)
-        _sector->status = Sector::DATA_MISSING; /* unintuitive but correct */
-}
-
-void MacintoshDecoder::decodeDataRecord()
-{
-    auto id = toBytes(readRawBits(24)).reader().read_be24();
-    if (id != MAC_DATA_RECORD)
-        return;
-
-    /* Read data. */
-
-    readRawBits(8); /* skip spare byte */
-    auto inputbuffer = toBytes(readRawBits(MAC_ENCODED_SECTOR_LENGTH*8))
-        .slice(0, MAC_ENCODED_SECTOR_LENGTH);
-
-    for (unsigned i=0; i<inputbuffer.size(); i++)
-        inputbuffer[i] = decode_data_gcr(inputbuffer[i]);
-        
-    _sector->status = Sector::BAD_CHECKSUM;
-    Bytes userData = decode_crazy_data(inputbuffer, _sector->status);
-    _sector->data.clear();
-    _sector->data.writer().append(userData.slice(12, 512)).append(userData.slice(0, 12));
-}
-
-std::set<unsigned> MacintoshDecoder::requiredSectors(Track& track) const
-{
-	int count;
-	if (track.physicalTrack < 16)
-		count = 12;
-	else if (track.physicalTrack < 32)
-		count = 11;
-	else if (track.physicalTrack < 48)
-		count = 10;
-	else if (track.physicalTrack < 64)
-		count = 9;
-	else
-		count = 8;
-
-	std::set<unsigned> sectors;
-	while (count--)
-		sectors.insert(count);
-	return sectors;
+	return std::unique_ptr<AbstractDecoder>(new MacintoshDecoder(config));
 }
 
 

--- a/arch/macintosh/macintosh.h
+++ b/arch/macintosh/macintosh.h
@@ -18,19 +18,6 @@ class Fluxmap;
 class MacintoshDecoderProto;
 class MacintoshEncoderProto;
 
-class MacintoshDecoder : public AbstractDecoder
-{
-public:
-	MacintoshDecoder(const MacintoshDecoderProto&) {}
-    virtual ~MacintoshDecoder() {}
-
-    RecordType advanceToNextRecord();
-    void decodeSectorRecord();
-    void decodeDataRecord();
-
-	std::set<unsigned> requiredSectors(Track& track) const;
-};
-
 class MacintoshEncoder : public AbstractEncoder
 {
 public:

--- a/arch/macintosh/macintosh.h
+++ b/arch/macintosh/macintosh.h
@@ -43,6 +43,7 @@ public:
 
 extern FlagGroup macintoshEncoderFlags;
 
+extern std::unique_ptr<AbstractDecoder> createMacintoshDecoder(const DecoderProto& config);
 
 #endif
 

--- a/arch/micropolis/decoder.cc
+++ b/arch/micropolis/decoder.cc
@@ -10,18 +10,6 @@
 /* The sector has a preamble of MFM 0x00s and uses 0xFF as a sync pattern. */
 static const FluxPattern SECTOR_SYNC_PATTERN(32, 0xaaaa5555);
 
-AbstractDecoder::RecordType MicropolisDecoder::advanceToNextRecord()
-{
-	_fmr->seekToIndexMark();
-	const FluxMatcher* matcher = nullptr;
-	_sector->clock = _fmr->seekToPattern(SECTOR_SYNC_PATTERN, matcher);
-	if (matcher == &SECTOR_SYNC_PATTERN) {
-		readRawBits(16);
-		return SECTOR_RECORD;
-	}
-	return UNKNOWN_RECORD;
-}
-
 /* Adds all bytes, with carry. */
 static uint8_t checksum(const Bytes& bytes) {
 	ByteReader br(bytes);
@@ -36,26 +24,52 @@ static uint8_t checksum(const Bytes& bytes) {
 	return sum & 0xFF;
 }
 
-void MicropolisDecoder::decodeSectorRecord()
+class MicropolisDecoder : public AbstractDecoder
 {
-	auto rawbits = readRawBits(MICROPOLIS_ENCODED_SECTOR_SIZE*16);
-	auto bytes = decodeFmMfm(rawbits).slice(0, MICROPOLIS_ENCODED_SECTOR_SIZE);
-	ByteReader br(bytes);
+public:
+	MicropolisDecoder(const DecoderProto& config):
+		AbstractDecoder(config)
+	{}
 
-	br.read_8();  /* sync */
-	_sector->logicalTrack = br.read_8();
-	_sector->logicalSide = _sector->physicalSide;
-	_sector->logicalSector = br.read_8();
-	if (_sector->logicalSector > 15)
-		return;
-	if (_sector->logicalTrack > 77)
-		return;
+	RecordType advanceToNextRecord()
+	{
+		_fmr->seekToIndexMark();
+		const FluxMatcher* matcher = nullptr;
+		_sector->clock = _fmr->seekToPattern(SECTOR_SYNC_PATTERN, matcher);
+		if (matcher == &SECTOR_SYNC_PATTERN) {
+			readRawBits(16);
+			return SECTOR_RECORD;
+		}
+		return UNKNOWN_RECORD;
+	}
 
-	br.read(10);  /* OS data or padding */
-	_sector->data = br.read(256);
-	uint8_t wantChecksum = br.read_8();
-	uint8_t gotChecksum = checksum(bytes.slice(1, 2+266));
-	br.read(5);  /* 4 byte ECC and ECC-present flag */
+	void decodeSectorRecord()
+	{
+		auto rawbits = readRawBits(MICROPOLIS_ENCODED_SECTOR_SIZE*16);
+		auto bytes = decodeFmMfm(rawbits).slice(0, MICROPOLIS_ENCODED_SECTOR_SIZE);
+		ByteReader br(bytes);
 
-	_sector->status = (wantChecksum == gotChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
+		br.read_8();  /* sync */
+		_sector->logicalTrack = br.read_8();
+		_sector->logicalSide = _sector->physicalSide;
+		_sector->logicalSector = br.read_8();
+		if (_sector->logicalSector > 15)
+			return;
+		if (_sector->logicalTrack > 77)
+			return;
+
+		br.read(10);  /* OS data or padding */
+		_sector->data = br.read(256);
+		uint8_t wantChecksum = br.read_8();
+		uint8_t gotChecksum = checksum(bytes.slice(1, 2+266));
+		br.read(5);  /* 4 byte ECC and ECC-present flag */
+
+		_sector->status = (wantChecksum == gotChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
+	}
+};
+
+std::unique_ptr<AbstractDecoder> createMicropolisDecoder(const DecoderProto& config)
+{
+	return std::unique_ptr<AbstractDecoder>(new MicropolisDecoder(config));
 }
+

--- a/arch/micropolis/micropolis.h
+++ b/arch/micropolis/micropolis.h
@@ -3,20 +3,6 @@
 
 #define MICROPOLIS_ENCODED_SECTOR_SIZE (1+2+266+6)
 
-class Sector;
-class Fluxmap;
-class MicropolisDecoderProto;
-
-class MicropolisDecoder : public AbstractDecoder
-{
-public:
-	MicropolisDecoder(const MicropolisDecoderProto&) {}
-	virtual ~MicropolisDecoder() {}
-
-	RecordType advanceToNextRecord();
-	void decodeSectorRecord();
-};
-
 extern std::unique_ptr<AbstractDecoder> createMicropolisDecoder(const DecoderProto& config);
 
 #endif

--- a/arch/micropolis/micropolis.h
+++ b/arch/micropolis/micropolis.h
@@ -17,4 +17,6 @@ public:
 	void decodeSectorRecord();
 };
 
+extern std::unique_ptr<AbstractDecoder> createMicropolisDecoder(const DecoderProto& config);
+
 #endif

--- a/arch/mx/decoder.cc
+++ b/arch/mx/decoder.cc
@@ -23,53 +23,73 @@ const int SECTOR_SIZE = 256;
  */
 const FluxPattern ID_PATTERN(32, 0xaaaaffaf);
 
-void MxDecoder::beginTrack()
+class MxDecoder : public AbstractDecoder
 {
-    _currentSector = -1;
-    _clock = 0;
+public:
+	MxDecoder(const DecoderProto& config):
+		AbstractDecoder(config)
+	{}
+
+    void beginTrack()
+	{
+		_currentSector = -1;
+		_clock = 0;
+	}
+
+    RecordType advanceToNextRecord()
+	{
+		if (_currentSector == -1)
+		{
+			/* First sector in the track: look for the sync marker. */
+			const FluxMatcher* matcher = nullptr;
+			_sector->clock = _clock = _fmr->seekToPattern(ID_PATTERN, matcher);
+			readRawBits(32); /* skip the ID mark */
+			_logicalTrack = decodeFmMfm(readRawBits(32)).slice(0, 32).reader().read_be16();
+		}
+		else if (_currentSector == 10)
+		{
+			/* That was the last sector on the disk. */
+			return UNKNOWN_RECORD;
+		}
+		else
+		{
+			/* Otherwise we assume the clock from the first sector is still valid.
+			 * The decoder framwork will automatically stop when we hit the end of
+			 * the track. */
+			_sector->clock = _clock;
+		}
+
+		_currentSector++;
+		return SECTOR_RECORD;
+	}
+
+    void decodeSectorRecord()
+	{
+		auto bits = readRawBits((SECTOR_SIZE+2)*16);
+		auto bytes = decodeFmMfm(bits).slice(0, SECTOR_SIZE+2).swab();
+
+		uint16_t gotChecksum = 0;
+		ByteReader br(bytes);
+		for (int i=0; i<(SECTOR_SIZE/2); i++)
+			gotChecksum += br.read_le16();
+		uint16_t wantChecksum = br.read_le16();
+
+		_sector->logicalTrack = _logicalTrack;
+		_sector->logicalSide = _track->physicalSide;
+		_sector->logicalSector = _currentSector;
+		_sector->data = bytes.slice(0, SECTOR_SIZE);
+		_sector->status = (gotChecksum == wantChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
+	}
+
+private:
+    nanoseconds_t _clock;
+    int _currentSector;
+    int _logicalTrack;
+};
+
+std::unique_ptr<AbstractDecoder> createMxDecoder(const DecoderProto& config)
+{
+	return std::unique_ptr<AbstractDecoder>(new MxDecoder(config));
 }
 
-AbstractDecoder::RecordType MxDecoder::advanceToNextRecord()
-{
-    if (_currentSector == -1)
-    {
-        /* First sector in the track: look for the sync marker. */
-        const FluxMatcher* matcher = nullptr;
-        _sector->clock = _clock = _fmr->seekToPattern(ID_PATTERN, matcher);
-        readRawBits(32); /* skip the ID mark */
-        _logicalTrack = decodeFmMfm(readRawBits(32)).slice(0, 32).reader().read_be16();
-    }
-    else if (_currentSector == 10)
-    {
-        /* That was the last sector on the disk. */
-        return UNKNOWN_RECORD;
-    }
-    else
-    {
-        /* Otherwise we assume the clock from the first sector is still valid.
-         * The decoder framwork will automatically stop when we hit the end of
-         * the track. */
-        _sector->clock = _clock;
-    }
 
-    _currentSector++;
-    return SECTOR_RECORD;
-}
-
-void MxDecoder::decodeSectorRecord()
-{
-    auto bits = readRawBits((SECTOR_SIZE+2)*16);
-    auto bytes = decodeFmMfm(bits).slice(0, SECTOR_SIZE+2).swab();
-
-    uint16_t gotChecksum = 0;
-    ByteReader br(bytes);
-    for (int i=0; i<(SECTOR_SIZE/2); i++)
-        gotChecksum += br.read_le16();
-    uint16_t wantChecksum = br.read_le16();
-
-    _sector->logicalTrack = _logicalTrack;
-    _sector->logicalSide = _track->physicalSide;
-    _sector->logicalSector = _currentSector;
-    _sector->data = bytes.slice(0, SECTOR_SIZE);
-    _sector->status = (gotChecksum == wantChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
-}

--- a/arch/mx/mx.h
+++ b/arch/mx/mx.h
@@ -3,24 +3,6 @@
 
 #include "decoders/decoders.h"
 
-class MxDecoderProto;
-
-class MxDecoder : public AbstractDecoder
-{
-public:
-	MxDecoder(const MxDecoderProto&) {}
-    virtual ~MxDecoder() {}
-
-    void beginTrack();
-    RecordType advanceToNextRecord();
-    void decodeSectorRecord();
-
-private:
-    nanoseconds_t _clock;
-    int _currentSector;
-    int _logicalTrack;
-};
-
 extern std::unique_ptr<AbstractDecoder> createMxDecoder(const DecoderProto& config);
 
 #endif

--- a/arch/mx/mx.h
+++ b/arch/mx/mx.h
@@ -21,4 +21,6 @@ private:
     int _logicalTrack;
 };
 
+extern std::unique_ptr<AbstractDecoder> createMxDecoder(const DecoderProto& config);
+
 #endif

--- a/arch/northstar/decoder.cc
+++ b/arch/northstar/decoder.cc
@@ -18,6 +18,7 @@
 #include "sector.h"
 #include "northstar.h"
 #include "bytes.h"
+#include "lib/decoders/decoders.pb.h"
 #include "fmt/format.h"
 
 /*
@@ -48,73 +49,6 @@ const FluxMatchers ANY_SECTOR_PATTERN(
 	}
 );
 
-/* Search for FM or MFM sector record */
-AbstractDecoder::RecordType NorthstarDecoder::advanceToNextRecord()
-{
-	nanoseconds_t now = _fmr->tell().ns();
-
-	/* For all but the first sector, seek to the next sector pulse.
-	 * The first sector does not contain the sector pulse in the fluxmap.
-	 */
-	if (now != 0) {
-		_fmr->seekToIndexMark();
-		now = _fmr->tell().ns();
-	}
-
-	/* Discard a possible partial sector at the end of the track.
-	 * This partial sector could be mistaken for a conflicted sector, if
-	 * whatever data read happens to match the checksum of 0, which is
-	 * rare, but has been observed on some disks.
-	 */
-	if (now > (_fmr->getDuration() - 21e6)) {
-		_fmr->seekToIndexMark();
-		return(UNKNOWN_RECORD);
-	}
-
-	int msSinceIndex = std::round(now / 1e6);
-
-	const FluxMatcher* matcher = nullptr;
-
-	/* Note that the seekToPattern ignores the sector pulses, so if
-	 * a sector is not found for some reason, the seek will advance
-	 * past one or more sector pulses.  For this reason, calculate
-	 * _hardSectorId after the sector header is found.
-	 */
-	_sector->clock = _fmr->seekToPattern(ANY_SECTOR_PATTERN, matcher);
-
-	int sectorFoundTimeRaw = std::round((_fmr->tell().ns()) / 1e6);
-	int sectorFoundTime;
-
-	/* Round time to the nearest 20ms */
-	if ((sectorFoundTimeRaw % 20) < 10) {
-		sectorFoundTime = (sectorFoundTimeRaw / 20) * 20;
-	}
-	else {
-		sectorFoundTime = ((sectorFoundTimeRaw + 20) / 20) * 20;
-	}
-
-	/* Calculate the sector ID based on time since the index */
-	_hardSectorId = (sectorFoundTime / 20) % 10;
-
-//	std::cout << fmt::format(
-//		"Sector ID {}: hole at {}ms, sector start at {}ms",
-//		_hardSectorId, msSinceIndex, sectorFoundTimeRaw) << std::endl;
-
-	if (matcher == &MFM_PATTERN) {
-		_sectorType = SECTOR_TYPE_MFM;
-		readRawBits(48);
-		return SECTOR_RECORD;
-	}
-
-	if (matcher == &FM_PATTERN) {
-		_sectorType = SECTOR_TYPE_FM;
-		readRawBits(48);
-		return SECTOR_RECORD;
-	}
-
-	return UNKNOWN_RECORD;
-}
-
 /* Checksum is initially 0.
  * For each data byte, XOR with the current checksum.
  * Rotate checksum left, carrying bit 7 to bit 0.
@@ -131,45 +65,134 @@ uint8_t northstarChecksum(const Bytes& bytes) {
 	return checksum;
 }
 
-void NorthstarDecoder::decodeSectorRecord()
+class NorthstarDecoder : public AbstractDecoder
 {
-	unsigned recordSize, payloadSize, headerSize;
+public:
+	NorthstarDecoder(const DecoderProto& config):
+		AbstractDecoder(config),
+		_config(config.northstar())
+	{}
 
-	if (_sectorType == SECTOR_TYPE_MFM) {
-		recordSize = NORTHSTAR_ENCODED_SECTOR_SIZE_DD;
-		payloadSize = NORTHSTAR_PAYLOAD_SIZE_DD;
-		headerSize = NORTHSTAR_HEADER_SIZE_DD;
+	/* Search for FM or MFM sector record */
+	RecordType advanceToNextRecord()
+	{
+		nanoseconds_t now = _fmr->tell().ns();
+
+		/* For all but the first sector, seek to the next sector pulse.
+		 * The first sector does not contain the sector pulse in the fluxmap.
+		 */
+		if (now != 0) {
+			_fmr->seekToIndexMark();
+			now = _fmr->tell().ns();
+		}
+
+		/* Discard a possible partial sector at the end of the track.
+		 * This partial sector could be mistaken for a conflicted sector, if
+		 * whatever data read happens to match the checksum of 0, which is
+		 * rare, but has been observed on some disks.
+		 */
+		if (now > (_fmr->getDuration() - 21e6)) {
+			_fmr->seekToIndexMark();
+			return(UNKNOWN_RECORD);
+		}
+
+		int msSinceIndex = std::round(now / 1e6);
+
+		const FluxMatcher* matcher = nullptr;
+
+		/* Note that the seekToPattern ignores the sector pulses, so if
+		 * a sector is not found for some reason, the seek will advance
+		 * past one or more sector pulses.  For this reason, calculate
+		 * _hardSectorId after the sector header is found.
+		 */
+		_sector->clock = _fmr->seekToPattern(ANY_SECTOR_PATTERN, matcher);
+
+		int sectorFoundTimeRaw = std::round((_fmr->tell().ns()) / 1e6);
+		int sectorFoundTime;
+
+		/* Round time to the nearest 20ms */
+		if ((sectorFoundTimeRaw % 20) < 10) {
+			sectorFoundTime = (sectorFoundTimeRaw / 20) * 20;
+		}
+		else {
+			sectorFoundTime = ((sectorFoundTimeRaw + 20) / 20) * 20;
+		}
+
+		/* Calculate the sector ID based on time since the index */
+		_hardSectorId = (sectorFoundTime / 20) % 10;
+
+	//	std::cout << fmt::format(
+	//		"Sector ID {}: hole at {}ms, sector start at {}ms",
+	//		_hardSectorId, msSinceIndex, sectorFoundTimeRaw) << std::endl;
+
+		if (matcher == &MFM_PATTERN) {
+			_sectorType = SECTOR_TYPE_MFM;
+			readRawBits(48);
+			return SECTOR_RECORD;
+		}
+
+		if (matcher == &FM_PATTERN) {
+			_sectorType = SECTOR_TYPE_FM;
+			readRawBits(48);
+			return SECTOR_RECORD;
+		}
+
+		return UNKNOWN_RECORD;
 	}
-	else {
-		recordSize = NORTHSTAR_ENCODED_SECTOR_SIZE_SD;
-		payloadSize = NORTHSTAR_PAYLOAD_SIZE_SD;
-		headerSize = NORTHSTAR_HEADER_SIZE_SD;
+
+	void decodeSectorRecord()
+	{
+		unsigned recordSize, payloadSize, headerSize;
+
+		if (_sectorType == SECTOR_TYPE_MFM) {
+			recordSize = NORTHSTAR_ENCODED_SECTOR_SIZE_DD;
+			payloadSize = NORTHSTAR_PAYLOAD_SIZE_DD;
+			headerSize = NORTHSTAR_HEADER_SIZE_DD;
+		}
+		else {
+			recordSize = NORTHSTAR_ENCODED_SECTOR_SIZE_SD;
+			payloadSize = NORTHSTAR_PAYLOAD_SIZE_SD;
+			headerSize = NORTHSTAR_HEADER_SIZE_SD;
+		}
+
+		auto rawbits = readRawBits(recordSize * 16);
+		auto bytes = decodeFmMfm(rawbits).slice(0, recordSize);
+		ByteReader br(bytes);
+		uint8_t sync_char;
+
+		_sector->logicalSide = _sector->physicalSide;
+		_sector->logicalSector = _hardSectorId;
+		_sector->logicalTrack = _sector->physicalTrack;
+
+		sync_char = br.read_8();	/* Sync char: 0xFB */
+		if (_sectorType == SECTOR_TYPE_MFM) {
+			sync_char = br.read_8();/* MFM second Sync char, usually 0xFB */
+		}
+
+		_sector->data = br.read(payloadSize);
+
+		uint8_t wantChecksum = br.read_8();
+		uint8_t gotChecksum = northstarChecksum(bytes.slice(headerSize, payloadSize));
+
+		_sector->status = (wantChecksum == gotChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
 	}
 
-	auto rawbits = readRawBits(recordSize * 16);
-	auto bytes = decodeFmMfm(rawbits).slice(0, recordSize);
-	ByteReader br(bytes);
-	uint8_t sync_char;
-
-	_sector->logicalSide = _sector->physicalSide;
-	_sector->logicalSector = _hardSectorId;
-	_sector->logicalTrack = _sector->physicalTrack;
-
-	sync_char = br.read_8();	/* Sync char: 0xFB */
-	if (_sectorType == SECTOR_TYPE_MFM) {
-		sync_char = br.read_8();/* MFM second Sync char, usually 0xFB */
+	std::set<unsigned> requiredSectors(Track& track) const
+	{
+		static std::set<unsigned> sectors = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+		return sectors;
 	}
 
-	_sector->data = br.read(payloadSize);
+private:
+	const NorthstarDecoderProto& _config;
+	uint8_t _sectorType = SECTOR_TYPE_MFM;
+	uint8_t _hardSectorId;
+};
 
-	uint8_t wantChecksum = br.read_8();
-	uint8_t gotChecksum = northstarChecksum(bytes.slice(headerSize, payloadSize));
-
-	_sector->status = (wantChecksum == gotChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
+std::unique_ptr<AbstractDecoder> createNorthstarDecoder(const DecoderProto& config)
+{
+	return std::unique_ptr<AbstractDecoder>(new NorthstarDecoder(config));
 }
 
-std::set<unsigned> NorthstarDecoder::requiredSectors(Track& track) const
-{
-	static std::set<unsigned> sectors = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-	return sectors;
-}
+
+

--- a/arch/northstar/northstar.h
+++ b/arch/northstar/northstar.h
@@ -69,4 +69,6 @@ private:
 extern FlagGroup northstarEncoderFlags;
 extern uint8_t northstarChecksum(const Bytes& bytes);
 
+extern std::unique_ptr<AbstractDecoder> createNorthstarDecoder(const DecoderProto& config);
+
 #endif /* NORTHSTAR */

--- a/arch/northstar/northstar.h
+++ b/arch/northstar/northstar.h
@@ -31,27 +31,6 @@
 class NorthstarEncoderProto;
 class NorthstarDecoderProto;
 
-class NorthstarDecoder : public AbstractDecoder
-{
-public:
-	NorthstarDecoder(const NorthstarDecoderProto& config):
-		_config(config)
-	{
-		_sectorType = SECTOR_TYPE_MFM;
-	}
-
-	virtual ~NorthstarDecoder() {}
-
-	RecordType advanceToNextRecord();
-	void decodeSectorRecord();
-	std::set<unsigned> requiredSectors(Track& track) const;
-
-private:
-	const NorthstarDecoderProto& _config;
-	uint8_t _sectorType;
-	uint8_t _hardSectorId;
-};
-
 class NorthstarEncoder : public AbstractEncoder
 {
 public:

--- a/arch/tids990/decoder.cc
+++ b/arch/tids990/decoder.cc
@@ -40,48 +40,61 @@ const FluxPattern DATA_RECORD_PATTERN(32, 0x11112245);
 
 const FluxMatchers ANY_RECORD_PATTERN({ &SECTOR_RECORD_PATTERN, &DATA_RECORD_PATTERN });
 
-AbstractDecoder::RecordType Tids990Decoder::advanceToNextRecord()
+class Tids990Decoder : public AbstractDecoder
 {
-	const FluxMatcher* matcher = nullptr;
-	_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
-	if (matcher == &SECTOR_RECORD_PATTERN)
-		return RecordType::SECTOR_RECORD;
-	if (matcher == &DATA_RECORD_PATTERN)
-		return RecordType::DATA_RECORD;
-	return RecordType::UNKNOWN_RECORD;
-}
+public:
+	Tids990Decoder(const DecoderProto& config):
+		AbstractDecoder(config)
+	{}
 
-void Tids990Decoder::decodeSectorRecord()
+    RecordType advanceToNextRecord()
+	{
+		const FluxMatcher* matcher = nullptr;
+		_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
+		if (matcher == &SECTOR_RECORD_PATTERN)
+			return RecordType::SECTOR_RECORD;
+		if (matcher == &DATA_RECORD_PATTERN)
+			return RecordType::DATA_RECORD;
+		return RecordType::UNKNOWN_RECORD;
+	}
+
+    void decodeSectorRecord()
+	{
+		auto bits = readRawBits(TIDS990_SECTOR_RECORD_SIZE*16);
+		auto bytes = decodeFmMfm(bits).slice(0, TIDS990_SECTOR_RECORD_SIZE);
+
+		ByteReader br(bytes);
+		uint16_t gotChecksum = crc16(CCITT_POLY, bytes.slice(1, TIDS990_SECTOR_RECORD_SIZE-3));
+
+		br.seek(2);
+		_sector->logicalSide = br.read_8() >> 3;
+		_sector->logicalTrack = br.read_8();
+		br.read_8(); /* number of sectors per track */
+		_sector->logicalSector = br.read_8();
+		br.read_be16(); /* sector size */
+		uint16_t wantChecksum = br.read_be16();
+
+		if (wantChecksum == gotChecksum)
+			_sector->status = Sector::DATA_MISSING; /* correct but unintuitive */
+	}
+
+	void decodeDataRecord()
+	{
+		auto bits = readRawBits(TIDS990_DATA_RECORD_SIZE*16);
+		auto bytes = decodeFmMfm(bits).slice(0, TIDS990_DATA_RECORD_SIZE);
+
+		ByteReader br(bytes);
+		uint16_t gotChecksum = crc16(CCITT_POLY, bytes.slice(1, TIDS990_DATA_RECORD_SIZE-3));
+
+		br.seek(2);
+		_sector->data = br.read(TIDS990_PAYLOAD_SIZE);
+		uint16_t wantChecksum = br.read_be16();
+		_sector->status = (wantChecksum == gotChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
+	}
+};
+
+std::unique_ptr<AbstractDecoder> createTids990Decoder(const DecoderProto& config)
 {
-    auto bits = readRawBits(TIDS990_SECTOR_RECORD_SIZE*16);
-    auto bytes = decodeFmMfm(bits).slice(0, TIDS990_SECTOR_RECORD_SIZE);
-
-    ByteReader br(bytes);
-	uint16_t gotChecksum = crc16(CCITT_POLY, bytes.slice(1, TIDS990_SECTOR_RECORD_SIZE-3));
-
-	br.seek(2);
-	_sector->logicalSide = br.read_8() >> 3;
-	_sector->logicalTrack = br.read_8();
-	br.read_8(); /* number of sectors per track */
-	_sector->logicalSector = br.read_8();
-	br.read_be16(); /* sector size */
-    uint16_t wantChecksum = br.read_be16();
-
-    if (wantChecksum == gotChecksum)
-        _sector->status = Sector::DATA_MISSING; /* correct but unintuitive */
-}
-
-void Tids990Decoder::decodeDataRecord()
-{
-	auto bits = readRawBits(TIDS990_DATA_RECORD_SIZE*16);
-	auto bytes = decodeFmMfm(bits).slice(0, TIDS990_DATA_RECORD_SIZE);
-
-	ByteReader br(bytes);
-	uint16_t gotChecksum = crc16(CCITT_POLY, bytes.slice(1, TIDS990_DATA_RECORD_SIZE-3));
-
-	br.seek(2);
-	_sector->data = br.read(TIDS990_PAYLOAD_SIZE);
-	uint16_t wantChecksum = br.read_be16();
-    _sector->status = (wantChecksum == gotChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
+	return std::unique_ptr<AbstractDecoder>(new Tids990Decoder(config));
 }
 

--- a/arch/tids990/tids990.h
+++ b/arch/tids990/tids990.h
@@ -49,6 +49,8 @@ private:
 
 extern FlagGroup tids990EncoderFlags;
 
+extern std::unique_ptr<AbstractDecoder> createTids990Decoder(const DecoderProto& config);
+
 #endif
 
 

--- a/arch/tids990/tids990.h
+++ b/arch/tids990/tids990.h
@@ -12,17 +12,6 @@ class Track;
 class Tids990DecoderProto;
 class Tids990EncoderProto;
 
-class Tids990Decoder : public AbstractDecoder
-{
-public:
-	Tids990Decoder(const Tids990DecoderProto&) {}
-    virtual ~Tids990Decoder() {}
-
-    RecordType advanceToNextRecord();
-    void decodeSectorRecord();
-	void decodeDataRecord();
-};
-
 class Tids990Encoder : public AbstractEncoder
 {
 public:

--- a/arch/victor9k/decoder.cc
+++ b/arch/victor9k/decoder.cc
@@ -54,58 +54,73 @@ static Bytes decode(const std::vector<bool>& bits)
     return output;
 }
 
-AbstractDecoder::RecordType Victor9kDecoder::advanceToNextRecord()
+class Victor9kDecoder : public AbstractDecoder
 {
-	const FluxMatcher* matcher = nullptr;
-	_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
-	if (matcher == &SECTOR_RECORD_PATTERN)
-		return SECTOR_RECORD;
-	if (matcher == &DATA_RECORD_PATTERN)
-		return DATA_RECORD;
-	return UNKNOWN_RECORD;
+public:
+	Victor9kDecoder(const DecoderProto& config):
+		AbstractDecoder(config)
+	{}
+
+    RecordType advanceToNextRecord()
+	{
+		const FluxMatcher* matcher = nullptr;
+		_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
+		if (matcher == &SECTOR_RECORD_PATTERN)
+			return SECTOR_RECORD;
+		if (matcher == &DATA_RECORD_PATTERN)
+			return DATA_RECORD;
+		return UNKNOWN_RECORD;
+	}
+
+    void decodeSectorRecord()
+	{
+		/* Skip the sync marker bit. */
+		readRawBits(23);
+
+		/* Read header. */
+
+		auto bytes = decode(readRawBits(4*10)).slice(0, 4);
+
+		uint8_t rawTrack = bytes[1];
+		_sector->logicalSector = bytes[2];
+		uint8_t gotChecksum = bytes[3];
+
+		_sector->logicalTrack = rawTrack & 0x7f;
+		_sector->logicalSide = rawTrack >> 7;
+		uint8_t wantChecksum = bytes[1] + bytes[2];
+		if ((_sector->logicalSector > 20) || (_sector->logicalTrack > 85) || (_sector->logicalSide > 1))
+			return;
+					
+		if (wantChecksum == gotChecksum)
+			_sector->status = Sector::DATA_MISSING; /* unintuitive but correct */
+	}
+
+    void decodeDataRecord()
+	{
+		/* Skip the sync marker bit. */
+		readRawBits(23);
+
+		/* Read data. */
+
+		auto bytes = decode(readRawBits((VICTOR9K_SECTOR_LENGTH+5)*10))
+			.slice(0, VICTOR9K_SECTOR_LENGTH+5);
+		ByteReader br(bytes);
+
+		/* Check that this is actually a data record. */
+		
+		if (br.read_8() != 8)
+			return;
+
+		_sector->data = br.read(VICTOR9K_SECTOR_LENGTH);
+		uint16_t gotChecksum = sumBytes(_sector->data);
+		uint16_t wantChecksum = br.read_le16();
+		_sector->status = (gotChecksum == wantChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
+	}
+};
+
+std::unique_ptr<AbstractDecoder> createVictor9kDecoder(const DecoderProto& config)
+{
+	return std::unique_ptr<AbstractDecoder>(new Victor9kDecoder(config));
 }
 
-void Victor9kDecoder::decodeSectorRecord()
-{
-    /* Skip the sync marker bit. */
-    readRawBits(23);
 
-    /* Read header. */
-
-    auto bytes = decode(readRawBits(4*10)).slice(0, 4);
-
-    uint8_t rawTrack = bytes[1];
-    _sector->logicalSector = bytes[2];
-    uint8_t gotChecksum = bytes[3];
-
-    _sector->logicalTrack = rawTrack & 0x7f;
-    _sector->logicalSide = rawTrack >> 7;
-    uint8_t wantChecksum = bytes[1] + bytes[2];
-    if ((_sector->logicalSector > 20) || (_sector->logicalTrack > 85) || (_sector->logicalSide > 1))
-        return;
-                
-    if (wantChecksum == gotChecksum)
-        _sector->status = Sector::DATA_MISSING; /* unintuitive but correct */
-}
-
-void Victor9kDecoder::decodeDataRecord()
-{
-    /* Skip the sync marker bit. */
-    readRawBits(23);
-
-    /* Read data. */
-
-    auto bytes = decode(readRawBits((VICTOR9K_SECTOR_LENGTH+5)*10))
-        .slice(0, VICTOR9K_SECTOR_LENGTH+5);
-    ByteReader br(bytes);
-
-    /* Check that this is actually a data record. */
-    
-    if (br.read_8() != 8)
-        return;
-
-    _sector->data = br.read(VICTOR9K_SECTOR_LENGTH);
-    uint16_t gotChecksum = sumBytes(_sector->data);
-    uint16_t wantChecksum = br.read_le16();
-    _sector->status = (gotChecksum == wantChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
-}

--- a/arch/victor9k/victor9k.h
+++ b/arch/victor9k/victor9k.h
@@ -21,4 +21,6 @@ public:
     void decodeDataRecord();
 };
 
+extern std::unique_ptr<AbstractDecoder> createVictor9kDecoder(const DecoderProto& config);
+
 #endif

--- a/arch/victor9k/victor9k.h
+++ b/arch/victor9k/victor9k.h
@@ -6,21 +6,6 @@
 
 #define VICTOR9K_SECTOR_LENGTH 512
 
-class Sector;
-class Fluxmap;
-class Victor9kDecoderProto;
-
-class Victor9kDecoder : public AbstractDecoder
-{
-public:
-	Victor9kDecoder(const Victor9kDecoderProto&) {}
-    virtual ~Victor9kDecoder() {}
-
-    RecordType advanceToNextRecord();
-    void decodeSectorRecord();
-    void decodeDataRecord();
-};
-
 extern std::unique_ptr<AbstractDecoder> createVictor9kDecoder(const DecoderProto& config);
 
 #endif

--- a/arch/zilogmcz/decoder.cc
+++ b/arch/zilogmcz/decoder.cc
@@ -14,35 +14,49 @@
 
 static const FluxPattern SECTOR_START_PATTERN(16, 0xaaab);
 
-AbstractDecoder::RecordType ZilogMczDecoder::advanceToNextRecord()
+class ZilogMczDecoder : public AbstractDecoder
 {
-	const FluxMatcher* matcher = nullptr;
-    _fmr->seekToIndexMark();
-	_sector->clock = _fmr->seekToPattern(SECTOR_START_PATTERN, matcher);
-	if (matcher == &SECTOR_START_PATTERN)
-		return SECTOR_RECORD;
-	return UNKNOWN_RECORD;
+public:
+	ZilogMczDecoder(const DecoderProto& config):
+		AbstractDecoder(config)
+	{}
+
+    RecordType advanceToNextRecord()
+	{
+		const FluxMatcher* matcher = nullptr;
+		_fmr->seekToIndexMark();
+		_sector->clock = _fmr->seekToPattern(SECTOR_START_PATTERN, matcher);
+		if (matcher == &SECTOR_START_PATTERN)
+			return SECTOR_RECORD;
+		return UNKNOWN_RECORD;
+	}
+
+    void decodeSectorRecord()
+	{
+		readRawBits(14);
+
+		auto rawbits = readRawBits(140*16);
+		auto bytes = decodeFmMfm(rawbits).slice(0, 140);
+		ByteReader br(bytes);
+
+		_sector->logicalSector = br.read_8() & 0x1f;
+		_sector->logicalSide = 0;
+		_sector->logicalTrack = br.read_8() & 0x7f;
+		if (_sector->logicalSector > 31)
+			return;
+		if (_sector->logicalTrack > 80)
+			return;
+
+		_sector->data = br.read(132);
+		uint16_t wantChecksum = br.read_be16();
+		uint16_t gotChecksum = crc16(MODBUS_POLY, 0x0000, bytes.slice(0, 134));
+
+		_sector->status = (wantChecksum == gotChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
+	}
+};
+
+std::unique_ptr<AbstractDecoder> createZilogMczDecoder(const DecoderProto& config)
+{
+	return std::unique_ptr<AbstractDecoder>(new ZilogMczDecoder(config));
 }
 
-void ZilogMczDecoder::decodeSectorRecord()
-{
-    readRawBits(14);
-
-    auto rawbits = readRawBits(140*16);
-    auto bytes = decodeFmMfm(rawbits).slice(0, 140);
-    ByteReader br(bytes);
-
-    _sector->logicalSector = br.read_8() & 0x1f;
-    _sector->logicalSide = 0;
-    _sector->logicalTrack = br.read_8() & 0x7f;
-    if (_sector->logicalSector > 31)
-        return;
-    if (_sector->logicalTrack > 80)
-        return;
-
-    _sector->data = br.read(132);
-    uint16_t wantChecksum = br.read_be16();
-    uint16_t gotChecksum = crc16(MODBUS_POLY, 0x0000, bytes.slice(0, 134));
-
-    _sector->status = (wantChecksum == gotChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
-}

--- a/arch/zilogmcz/zilogmcz.h
+++ b/arch/zilogmcz/zilogmcz.h
@@ -15,6 +15,8 @@ public:
     void decodeSectorRecord();
 };
 
+extern std::unique_ptr<AbstractDecoder> createZilogMczDecoder(const DecoderProto& config);
+
 #endif
 
 

--- a/arch/zilogmcz/zilogmcz.h
+++ b/arch/zilogmcz/zilogmcz.h
@@ -1,20 +1,6 @@
 #ifndef ZILOGMCZ_H
 #define ZILOGMCZ_H
 
-class Sector;
-class Fluxmap;
-class ZilogMczDecoderProto;
-
-class ZilogMczDecoder : public AbstractDecoder
-{
-public:
-	ZilogMczDecoder(const ZilogMczDecoderProto&) {}
-    virtual ~ZilogMczDecoder() {}
-
-    RecordType advanceToNextRecord();
-    void decodeSectorRecord();
-};
-
 extern std::unique_ptr<AbstractDecoder> createZilogMczDecoder(const DecoderProto& config);
 
 #endif

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -46,6 +46,7 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 		{ DecoderProto::kMx,         createMxDecoder },
 		{ DecoderProto::kNorthstar,  createNorthstarDecoder },
 		{ DecoderProto::kTids990,    createTids990Decoder },
+		{ DecoderProto::kVictor9K,   createVictor9kDecoder },
 	};
 
 	auto decoder = decoders.find(config.format_case());
@@ -60,9 +61,6 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 {
 	switch (config.format_case())
 	{
-		case DecoderProto::kVictor9K:
-			return std::unique_ptr<AbstractDecoder>(new Victor9kDecoder(config.victor9k()));
-
 		case DecoderProto::kZilogmcz:
 			return std::unique_ptr<AbstractDecoder>(new ZilogMczDecoder(config.zilogmcz()));
 

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -37,6 +37,7 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 		{ DecoderProto::kApple2,    createApple2Decoder },
 		{ DecoderProto::kBrother,   createBrotherDecoder },
 		{ DecoderProto::kC64,       createCommodore64Decoder },
+		{ DecoderProto::kF85,       createDurangoF85Decoder },
 	};
 
 	auto decoder = decoders.find(config.format_case());
@@ -51,9 +52,6 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 {
 	switch (config.format_case())
 	{
-		case DecoderProto::kC64:
-			return std::unique_ptr<AbstractDecoder>(new Commodore64Decoder(config.c64()));
-
 		case DecoderProto::kF85:
 			return std::unique_ptr<AbstractDecoder>(new DurangoF85Decoder(config.f85()));
 

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -9,6 +9,7 @@
 #include "arch/brother/brother.h"
 #include "arch/c64/c64.h"
 #include "arch/f85/f85.h"
+#include "arch/fb100/fb100.h"
 #include "arch/ibm/ibm.h"
 #include "arch/macintosh/macintosh.h"
 #include "arch/micropolis/micropolis.h"
@@ -38,6 +39,7 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 		{ DecoderProto::kBrother,   createBrotherDecoder },
 		{ DecoderProto::kC64,       createCommodore64Decoder },
 		{ DecoderProto::kF85,       createDurangoF85Decoder },
+		{ DecoderProto::kFb100,     createFb100Decoder },
 	};
 
 	auto decoder = decoders.find(config.format_case());
@@ -52,9 +54,6 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 {
 	switch (config.format_case())
 	{
-		case DecoderProto::kF85:
-			return std::unique_ptr<AbstractDecoder>(new DurangoF85Decoder(config.f85()));
-
 		case DecoderProto::kIbm:
 			return std::unique_ptr<AbstractDecoder>(new IbmDecoder(config.ibm()));
 

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -40,6 +40,7 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 		{ DecoderProto::kC64,       createCommodore64Decoder },
 		{ DecoderProto::kF85,       createDurangoF85Decoder },
 		{ DecoderProto::kFb100,     createFb100Decoder },
+		{ DecoderProto::kIbm,       createIbmDecoder },
 	};
 
 	auto decoder = decoders.find(config.format_case());

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -43,6 +43,7 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 		{ DecoderProto::kIbm,        createIbmDecoder },
 		{ DecoderProto::kMacintosh,  createMacintoshDecoder },
 		{ DecoderProto::kMicropolis, createMicropolisDecoder },
+		{ DecoderProto::kMx,         createMxDecoder },
 	};
 
 	auto decoder = decoders.find(config.format_case());
@@ -57,9 +58,6 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 {
 	switch (config.format_case())
 	{
-		case DecoderProto::kMx:
-			return std::unique_ptr<AbstractDecoder>(new MxDecoder(config.mx()));
-
 		case DecoderProto::kTids990:
 			return std::unique_ptr<AbstractDecoder>(new Tids990Decoder(config.tids990()));
 

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -44,6 +44,7 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 		{ DecoderProto::kMacintosh,  createMacintoshDecoder },
 		{ DecoderProto::kMicropolis, createMicropolisDecoder },
 		{ DecoderProto::kMx,         createMxDecoder },
+		{ DecoderProto::kTids990,    createTids990Decoder },
 	};
 
 	auto decoder = decoders.find(config.format_case());
@@ -58,9 +59,6 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 {
 	switch (config.format_case())
 	{
-		case DecoderProto::kTids990:
-			return std::unique_ptr<AbstractDecoder>(new Tids990Decoder(config.tids990()));
-
 		case DecoderProto::kVictor9K:
 			return std::unique_ptr<AbstractDecoder>(new Victor9kDecoder(config.victor9k()));
 

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -29,6 +29,22 @@
 
 std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& config)
 {
+	static const std::map<int,
+		std::function<std::unique_ptr<AbstractDecoder>(const DecoderProto&)>> decoders =
+	{
+		{ DecoderProto::kAmiga, createAmigaDecoder },
+	};
+
+	auto decoder = decoders.find(config.format_case());
+	if (decoder == decoders.end())
+		Error() << "no decoder specified";
+
+	return (decoder->second)(config);
+}
+
+#if 0
+std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& config)
+{
 	switch (config.format_case())
 	{
 		case DecoderProto::kAeslanier:
@@ -79,6 +95,7 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 
 	return std::unique_ptr<AbstractDecoder>();
 }
+#endif
 
 void AbstractDecoder::decodeToSectors(Track& track)
 {

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -41,6 +41,7 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 		{ DecoderProto::kF85,       createDurangoF85Decoder },
 		{ DecoderProto::kFb100,     createFb100Decoder },
 		{ DecoderProto::kIbm,       createIbmDecoder },
+		{ DecoderProto::kMacintosh, createMacintoshDecoder },
 	};
 
 	auto decoder = decoders.find(config.format_case());
@@ -55,12 +56,6 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 {
 	switch (config.format_case())
 	{
-		case DecoderProto::kIbm:
-			return std::unique_ptr<AbstractDecoder>(new IbmDecoder(config.ibm()));
-
-		case DecoderProto::kMacintosh:
-			return std::unique_ptr<AbstractDecoder>(new MacintoshDecoder(config.macintosh()));
-
 		case DecoderProto::kMicropolis:
 			return std::unique_ptr<AbstractDecoder>(new MicropolisDecoder(config.micropolis()));
 

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -44,6 +44,7 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 		{ DecoderProto::kMacintosh,  createMacintoshDecoder },
 		{ DecoderProto::kMicropolis, createMicropolisDecoder },
 		{ DecoderProto::kMx,         createMxDecoder },
+		{ DecoderProto::kNorthstar,  createNorthstarDecoder },
 		{ DecoderProto::kTids990,    createTids990Decoder },
 	};
 
@@ -64,9 +65,6 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 
 		case DecoderProto::kZilogmcz:
 			return std::unique_ptr<AbstractDecoder>(new ZilogMczDecoder(config.zilogmcz()));
-
-		case DecoderProto::kNorthstar:
-			return std::unique_ptr<AbstractDecoder>(new NorthstarDecoder(config.northstar()));
 
 		default:
 			Error() << "no input disk format specified";

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -33,15 +33,16 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 	static const std::map<int,
 		std::function<std::unique_ptr<AbstractDecoder>(const DecoderProto&)>> decoders =
 	{
-		{ DecoderProto::kAeslanier, createAesLanierDecoder },
-		{ DecoderProto::kAmiga,     createAmigaDecoder },
-		{ DecoderProto::kApple2,    createApple2Decoder },
-		{ DecoderProto::kBrother,   createBrotherDecoder },
-		{ DecoderProto::kC64,       createCommodore64Decoder },
-		{ DecoderProto::kF85,       createDurangoF85Decoder },
-		{ DecoderProto::kFb100,     createFb100Decoder },
-		{ DecoderProto::kIbm,       createIbmDecoder },
-		{ DecoderProto::kMacintosh, createMacintoshDecoder },
+		{ DecoderProto::kAeslanier,  createAesLanierDecoder },
+		{ DecoderProto::kAmiga,      createAmigaDecoder },
+		{ DecoderProto::kApple2,     createApple2Decoder },
+		{ DecoderProto::kBrother,    createBrotherDecoder },
+		{ DecoderProto::kC64,        createCommodore64Decoder },
+		{ DecoderProto::kF85,        createDurangoF85Decoder },
+		{ DecoderProto::kFb100,      createFb100Decoder },
+		{ DecoderProto::kIbm,        createIbmDecoder },
+		{ DecoderProto::kMacintosh,  createMacintoshDecoder },
+		{ DecoderProto::kMicropolis, createMicropolisDecoder },
 	};
 
 	auto decoder = decoders.find(config.format_case());
@@ -56,9 +57,6 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 {
 	switch (config.format_case())
 	{
-		case DecoderProto::kMicropolis:
-			return std::unique_ptr<AbstractDecoder>(new MicropolisDecoder(config.micropolis()));
-
 		case DecoderProto::kMx:
 			return std::unique_ptr<AbstractDecoder>(new MxDecoder(config.mx()));
 

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -36,6 +36,7 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 		{ DecoderProto::kAmiga,     createAmigaDecoder },
 		{ DecoderProto::kApple2,    createApple2Decoder },
 		{ DecoderProto::kBrother,   createBrotherDecoder },
+		{ DecoderProto::kC64,       createCommodore64Decoder },
 	};
 
 	auto decoder = decoders.find(config.format_case());
@@ -50,9 +51,6 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 {
 	switch (config.format_case())
 	{
-		case DecoderProto::kBrother:
-			return std::unique_ptr<AbstractDecoder>(new BrotherDecoder(config.brother()));
-
 		case DecoderProto::kC64:
 			return std::unique_ptr<AbstractDecoder>(new Commodore64Decoder(config.c64()));
 

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -47,6 +47,7 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 		{ DecoderProto::kNorthstar,  createNorthstarDecoder },
 		{ DecoderProto::kTids990,    createTids990Decoder },
 		{ DecoderProto::kVictor9K,   createVictor9kDecoder },
+		{ DecoderProto::kZilogmcz,   createZilogMczDecoder },
 	};
 
 	auto decoder = decoders.find(config.format_case());
@@ -55,22 +56,6 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 
 	return (decoder->second)(config);
 }
-
-#if 0
-std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& config)
-{
-	switch (config.format_case())
-	{
-		case DecoderProto::kZilogmcz:
-			return std::unique_ptr<AbstractDecoder>(new ZilogMczDecoder(config.zilogmcz()));
-
-		default:
-			Error() << "no input disk format specified";
-	}
-
-	return std::unique_ptr<AbstractDecoder>();
-}
-#endif
 
 void AbstractDecoder::decodeToSectors(Track& track)
 {

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -35,6 +35,7 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 		{ DecoderProto::kAeslanier, createAesLanierDecoder },
 		{ DecoderProto::kAmiga,     createAmigaDecoder },
 		{ DecoderProto::kApple2,    createApple2Decoder },
+		{ DecoderProto::kBrother,   createBrotherDecoder },
 	};
 
 	auto decoder = decoders.find(config.format_case());
@@ -49,9 +50,6 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 {
 	switch (config.format_case())
 	{
-		case DecoderProto::kApple2:
-			return std::unique_ptr<AbstractDecoder>(new Apple2Decoder(config.apple2()));
-
 		case DecoderProto::kBrother:
 			return std::unique_ptr<AbstractDecoder>(new BrotherDecoder(config.brother()));
 

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -34,6 +34,7 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 	{
 		{ DecoderProto::kAeslanier, createAesLanierDecoder },
 		{ DecoderProto::kAmiga,     createAmigaDecoder },
+		{ DecoderProto::kApple2,    createApple2Decoder },
 	};
 
 	auto decoder = decoders.find(config.format_case());
@@ -48,9 +49,6 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 {
 	switch (config.format_case())
 	{
-		case DecoderProto::kAeslanier:
-			return std::unique_ptr<AbstractDecoder>(new AesLanierDecoder(config.aeslanier()));
-
 		case DecoderProto::kApple2:
 			return std::unique_ptr<AbstractDecoder>(new Apple2Decoder(config.apple2()));
 

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -32,7 +32,8 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 	static const std::map<int,
 		std::function<std::unique_ptr<AbstractDecoder>(const DecoderProto&)>> decoders =
 	{
-		{ DecoderProto::kAmiga, createAmigaDecoder },
+		{ DecoderProto::kAeslanier, createAesLanierDecoder },
+		{ DecoderProto::kAmiga,     createAmigaDecoder },
 	};
 
 	auto decoder = decoders.find(config.format_case());
@@ -49,9 +50,6 @@ std::unique_ptr<AbstractDecoder> AbstractDecoder::create(const DecoderProto& con
 	{
 		case DecoderProto::kAeslanier:
 			return std::unique_ptr<AbstractDecoder>(new AesLanierDecoder(config.aeslanier()));
-
-		case DecoderProto::kAmiga:
-			return std::unique_ptr<AbstractDecoder>(new AmigaDecoder(config.amiga()));
 
 		case DecoderProto::kApple2:
 			return std::unique_ptr<AbstractDecoder>(new Apple2Decoder(config.apple2()));

--- a/lib/decoders/decoders.h
+++ b/lib/decoders/decoders.h
@@ -31,6 +31,9 @@ static inline Bytes decodeFmMfm(const std::vector<bool> bits)
 class AbstractDecoder
 {
 public:
+	AbstractDecoder() {} // REMOVE ME
+	AbstractDecoder(const DecoderProto& config) {}
+
     virtual ~AbstractDecoder() {}
 
 	static std::unique_ptr<AbstractDecoder> create(const DecoderProto& config);


### PR DESCRIPTION
There's no need to expose the class structure; moving it to the implementation file simplifies the interface a lot and should hopefully lead to faster compilation.