### PR TITLE
Fix swap_sides on the IBM encoder/decoder.

### DIFF
--- a/arch/ibm/decoder.cc
+++ b/arch/ibm/decoder.cc
@@ -147,6 +147,8 @@ public:
 		if (wantCrc == gotCrc)
 			_sector->status = Sector::DATA_MISSING; /* correct but unintuitive */
 
+		if (_config.swap_sides())
+			_sector->logicalSide = 1 - _sector->logicalSide;
 		if (_config.ignore_side_byte())
 			_sector->logicalSide = _sector->physicalHead;
 	}

--- a/arch/ibm/ibm.proto
+++ b/arch/ibm/ibm.proto
@@ -6,6 +6,7 @@ message IbmDecoderProto {
 	optional int32 sector_id_base = 1        [default = 1, (help) = "ID of first sector"];
 	optional bool ignore_side_byte = 2       [default = false, (help) = "ignore side byte in sector header"];
 	optional RangeProto required_sectors = 3 [(help) = "require these sectors to exist for a good read"];
+	optional bool swap_sides = 4             [default = false, (help) = "swap side bytes when reading"];
 }
 
 message IbmEncoderProto {

--- a/lib/encoders/encoders.h
+++ b/lib/encoders/encoders.h
@@ -10,6 +10,7 @@ class AbstractEncoder
 {
 public:
     AbstractEncoder(const EncoderProto& config) {}
+	virtual ~AbstractEncoder() {}
 
 	static std::unique_ptr<AbstractEncoder> create(const EncoderProto& config);
 

--- a/src/formats/atarist360.textpb
+++ b/src/formats/atarist360.textpb
@@ -33,7 +33,9 @@ encoder {
 }
 
 decoder {
-	ibm {}
+	ibm {
+		swap_sides: true
+	}
 }
 
 cylinders {

--- a/src/formats/atarist370.textpb
+++ b/src/formats/atarist370.textpb
@@ -33,7 +33,9 @@ encoder {
 }
 
 decoder {
-	ibm {}
+	ibm {
+		swap_sides: true
+	}
 }
 
 cylinders {

--- a/src/formats/atarist400.textpb
+++ b/src/formats/atarist400.textpb
@@ -33,7 +33,9 @@ encoder {
 }
 
 decoder {
-	ibm {}
+	ibm {
+		swap_sides: true
+	}
 }
 
 cylinders {

--- a/src/formats/atarist410.textpb
+++ b/src/formats/atarist410.textpb
@@ -33,7 +33,9 @@ encoder {
 }
 
 decoder {
-	ibm {}
+	ibm {
+		swap_sides: true
+	}
 }
 
 cylinders {

--- a/src/formats/atarist720.textpb
+++ b/src/formats/atarist720.textpb
@@ -33,7 +33,9 @@ encoder {
 }
 
 decoder {
-	ibm {}
+	ibm {
+		swap_sides: true
+	}
 }
 
 cylinders {

--- a/src/formats/atarist740.textpb
+++ b/src/formats/atarist740.textpb
@@ -33,7 +33,9 @@ encoder {
 }
 
 decoder {
-	ibm {}
+	ibm {
+		swap_sides: true
+	}
 }
 
 cylinders {

--- a/src/formats/atarist800.textpb
+++ b/src/formats/atarist800.textpb
@@ -33,7 +33,9 @@ encoder {
 }
 
 decoder {
-	ibm {}
+	ibm {
+		swap_sides: true
+	}
 }
 
 cylinders {

--- a/src/formats/atarist820.textpb
+++ b/src/formats/atarist820.textpb
@@ -33,7 +33,9 @@ encoder {
 }
 
 decoder {
-	ibm {}
+	ibm {
+		swap_sides: true
+	}
 }
 
 cylinders {

--- a/src/formats/commodore1581.textpb
+++ b/src/formats/commodore1581.textpb
@@ -40,7 +40,9 @@ encoder {
 }
 
 decoder {
-	ibm {}
+	ibm {
+		swap_sides: true
+	}
 }
 
 cylinders {


### PR DESCRIPTION
This was causing the commodore1581 and all the atari formats not to work properly.

See: #307