### PR TITLE
The 1581 format doesn't need swap_sides.

### DIFF
--- a/src/formats/commodore1581.textpb
+++ b/src/formats/commodore1581.textpb
@@ -34,15 +34,12 @@ encoder {
 			gap2: 22
 			gap3: 34
 			sector_skew: "0123456789"
-			swap_sides: true
 		}
 	}
 }
 
 decoder {
-	ibm {
-		swap_sides: true
-	}
+	ibm {}
 }
 
 cylinders {


### PR DESCRIPTION
eom

Fixes: #307