### PR TITLE
Redirect dd to stdout instead of file '1'

### DIFF
--- a/scripts/encodedecodetest.sh
+++ b/scripts/encodedecodetest.sh
@@ -15,7 +15,7 @@ shift
 
 trap "rm -f $srcfile $fluxfile $destfile" EXIT
 
-dd if=/dev/urandom of=$srcfile bs=1M count=2 2>1
+dd if=/dev/urandom of=$srcfile bs=1M count=2 2>&1
 
 ./fluxengine write $format -i $srcfile -d $fluxfile "$@"
 ./fluxengine read $format -s $fluxfile -o $destfile "$@"


### PR DESCRIPTION
Looks like a typo, that would have had mostly the intended effect.