### PR TITLE
Add Japanese PC 1.2MB format.

### DIFF
--- a/mkninja.sh
+++ b/mkninja.sh
@@ -416,6 +416,7 @@ FORMATS="\
     hplif770 \
     ibm \
     ibm1200_525 \
+    ibm1232 \
     ibm1440 \
     ibm180_525 \
     ibm360_525 \
@@ -521,6 +522,7 @@ encodedecodetest atarist820
 encodedecodetest brother120
 encodedecodetest brother240
 encodedecodetest ibm1200_525
+encodedecodetest ibm1232
 encodedecodetest ibm1440
 encodedecodetest ibm180_525
 encodedecodetest ibm360_525

--- a/src/formats/ibm1232.textpb
+++ b/src/formats/ibm1232.textpb
@@ -1,0 +1,68 @@
+comment: 'Japanese PC 1232kB 5.25"/3.5" 77-track 8-sector DSHD'
+
+flux_sink {
+	drive {
+		high_density: true
+	}
+}
+
+flux_source {
+	drive {
+		high_density: true
+	}
+}
+
+image_reader {
+	filename: "ibm1232.img"
+	img {
+		tracks: 77
+		sides: 2
+		trackdata {
+			sector_size: 1024
+			sector_range {
+				start_sector: 1
+				sector_count: 8
+			}
+		}
+	}
+}
+
+image_writer {
+	filename: "ibm1232.img"
+	img {}
+}
+
+encoder {
+	ibm {
+		trackdata {
+            sector_size: 1024
+			track_length_ms: 167
+			clock_rate_khz: 500
+			sectors {
+				sector: 1
+				sector: 2
+				sector: 3
+				sector: 4
+				sector: 5
+				sector: 6
+				sector: 7
+				sector: 8
+			}
+		}
+	}
+}
+
+decoder {
+	ibm {}
+}
+
+cylinders {
+	start: 0
+	end: 76
+}
+
+heads {
+	start: 0
+	end: 1
+}
+


### PR DESCRIPTION
This format is used by the PC-98 and Sharp X68000 series.

3.5" disks are spun at 360rpm to match the clock rate of 5.25".
