### PR TITLE
Add alias for XDF image files.

### DIFF
--- a/doc/using.md
+++ b/doc/using.md
@@ -233,7 +233,7 @@ FluxEngine supports a number of ways to get or put flux. When using the `-s` or
 FluxEngine also supports a number of file system image formats. When using the
 `-i` or `-o` options (for input and output), you can use any of these strings:
 
-  - `<filename.adf>`, `<filename.d81>`, `<filename.img>`, `<filename.st>`
+  - `<filename.adf>`, `<filename.d81>`, `<filename.img>`, `<filename.st>`, `<filename.xdf>`
 
 	Read from or write to a simple headerless image file (all these formats are
 	the same). This will probably want configuration via the

--- a/lib/imagereader/imagereader.cc
+++ b/lib/imagereader/imagereader.cc
@@ -55,6 +55,7 @@ void ImageReader::updateConfigForFilename(ImageReaderProto* proto, const std::st
 		{".nsi",      [&]() { proto->mutable_nsi(); }},
 		{".td0",      [&]() { proto->mutable_td0(); }},
 		{".TD0",      [&]() { proto->mutable_td0(); }},
+		{".xdf",      [&]() { proto->mutable_img(); }},
 	};
 
 	for (const auto& it : formats)

--- a/lib/imagewriter/imagewriter.cc
+++ b/lib/imagewriter/imagewriter.cc
@@ -47,6 +47,7 @@ void ImageWriter::updateConfigForFilename(ImageWriterProto* proto, const std::st
 		{".ldbs",     [&]() { proto->mutable_ldbs(); }},
 		{".st",       [&]() { proto->mutable_img(); }},
 		{".nsi",      [&]() { proto->mutable_nsi(); }},
+		{".xdf",      [&]() { proto->mutable_img(); }},
 	};
 
 	for (const auto& it : formats)


### PR DESCRIPTION
This is a common extension for Sharp X68000 bare disk images.
