### PR TITLE
Fix reported size of DIM and FDI images.

### DIFF
--- a/lib/imagereader/dimimagereader.cc
+++ b/lib/imagereader/dimimagereader.cc
@@ -100,7 +100,7 @@ public:
 		const Geometry& geometry = image.getGeometry();
         std::cout << fmt::format("DIM: read {} tracks, {} sides, {} kB total\n",
                         geometry.numTracks, geometry.numSides,
-						inputFile.tellg() / 1024);
+						((int)inputFile.tellg() - 256) / 1024);
         return image;
 	}
 

--- a/lib/imagereader/fdiimagereader.cc
+++ b/lib/imagereader/fdiimagereader.cc
@@ -80,7 +80,7 @@ public:
 		const Geometry& geometry = image.getGeometry();
         std::cout << fmt::format("FDI: read {} tracks, {} sides, {} kB total\n",
                         geometry.numTracks, geometry.numSides,
-						inputFile.tellg() / 1024);
+						((int)inputFile.tellg() - headerSize) / 1024);
         return image;
 	}
 


### PR DESCRIPTION
The computation for size accidentally included header size.
