### PR TITLE
Add option to rescale flux sink pulses. 

### DIFF
--- a/doc/using.md
+++ b/doc/using.md
@@ -338,6 +338,14 @@ behaviour.
 	has no effect on the _drive_, so it doesn't help with flippy disks, but is
 	useful for using very old drives with FluxEngine itself. If you use this
 	option, then any index marks in the sampled flux are, of course, garbage.
+  
+  - `--flux_sink.rescale=X`
+  
+  When writing a floppy on a drive that doesn't match the source file rpm,
+  the flux periods can be scaled to compensate. For example, to write
+  a PC-98 1.2MB (360rpm) floppy using a 300rpm floppy drive:
+  
+  `--flux_sink.rescale=1.2`
 
 ## Visualisation
 

--- a/lib/fluxmap.cc
+++ b/lib/fluxmap.cc
@@ -108,3 +108,22 @@ std::vector<Fluxmap> Fluxmap::split() {
     maps.push_back(map);
     return maps;
 }
+
+void Fluxmap::rescale(double scale) {
+    if (scale != 1.0) {
+        auto bytesOrig = _bytes;
+        _bytes = Bytes();
+        _duration = 0;
+        _ticks = 0;
+        int lastEvent = 0;
+        for (unsigned i=0; i<bytesOrig.size(); i++)
+        {
+            lastEvent += bytesOrig[i] & 0x3f;
+            if (bytesOrig[i] & 0xc0) {
+                appendInterval(lastEvent * scale + 0.5);
+                findLastByte() |= bytesOrig[i] & 0xc0;
+                lastEvent = 0;
+            }
+        }
+    }
+}

--- a/lib/fluxmap.h
+++ b/lib/fluxmap.h
@@ -60,6 +60,7 @@ public:
 
     void precompensate(int threshold_ticks, int amount_ticks);
     std::vector<Fluxmap> split();
+    void rescale(double scale);
 
 private:
 	uint8_t& findLastByte();

--- a/lib/fluxsink/fluxsink.proto
+++ b/lib/fluxsink/fluxsink.proto
@@ -29,6 +29,7 @@ message Fl2FluxSinkProto {
 }
 
 message FluxSinkProto {
+    optional double rescale = 7 [ default = 1.0, (help) = "amount to multiply pulse periods by" ];
 	oneof dest {
 		string fluxfile = 1 [(help) = "name of destination flux file"];
 		HardwareFluxSinkProto drive = 2;

--- a/lib/writer.cc
+++ b/lib/writer.cc
@@ -40,6 +40,7 @@ void writeTracks(
 			}
 			else
 			{
+				fluxmap->rescale(config.flux_sink().rescale());
 				/* Precompensation actually seems to make things worse, so let's leave
 					* it disabled for now. */
 				//fluxmap->precompensate(PRECOMPENSATION_THRESHOLD_TICKS, 2);
@@ -77,6 +78,7 @@ void writeTracksAndVerify(
 			}
 			else
 			{
+				fluxmap->rescale(config.flux_sink().rescale());
 				std::sort(sectors.begin(), sectors.end(), sectorPointerSortPredicate);
 
 				for (int retry = 0;; retry++)


### PR DESCRIPTION
Note that this does not affect the decoder used for verify,
but at least for tame rescaling the decoders are still able to
lock.

This is a precursor to automatic scaling via the disk speed
measurement.