### PR TITLE
Fix SCP writer to always write complete revolutions.

### DIFF
--- a/lib/fluxsink/fluxsink.proto
+++ b/lib/fluxsink/fluxsink.proto
@@ -20,7 +20,7 @@ message VcdFluxSinkProto {
 
 message ScpFluxSinkProto {
 	optional string filename = 2       [default = "flux.scp", (help) = ".scp file to write to"];
-	optional bool align_with_index = 3 [default = false, (help) = "align data to track boundaries"];
+	optional bool align_with_index = 3 [default = false, (help) = "discard data before the first index pulse"];
 	optional int32 type_byte = 4       [default = 0xff, (help) = "set the SCP disk type byte"];
 }
 


### PR DESCRIPTION
There were a couple of problems that needed to be fixed:

- Fluxmaps can be produced with zero index pulses by encoders.
This is somewhat ambiguous but it's assumed that this means there
is exactly one revolution.

- The SCP unindexed mode wasn't properly supported, as it should
create equal-length revolutions not aligned to indexes. However,
fluxmaps don't contain any information on rotation speed. Therefore,
drop the ability to create unindexed SCPs and slightly change the
meaning of the option to not include pre-index data.

- Real flux reads can potentially produce duplicate index pulses.
Avoid creating zero-length revs.

- Fix off-by-one error for rev count.
