### PR TITLE
Add ibm_n88basic format.

### DIFF
--- a/mkninja.sh
+++ b/mkninja.sh
@@ -440,6 +440,7 @@ FORMATS="\
     mac800 \
     micropolis \
     mx \
+    n88basic \
     northstar175 \
     northstar350 \
     northstar87 \
@@ -541,6 +542,7 @@ encodedecodetest ibm180_525
 encodedecodetest ibm360_525
 encodedecodetest ibm720
 encodedecodetest ibm720_525
+encodedecodetest n88basic
 encodedecodetest tids990
 encodedecodetest commodore1581
 encodedecodetest commodore1541 scripts/commodore1541_test.textpb

--- a/src/formats/n88basic.textpb
+++ b/src/formats/n88basic.textpb
@@ -1,0 +1,134 @@
+comment: 'N88-BASIC 5.25"/3.5" 77-track 26-sector DSHD'
+
+flux_sink {
+	drive {
+		high_density: true
+	}
+}
+
+flux_source {
+	drive {
+		high_density: true
+	}
+}
+
+image_reader {
+	filename: "n88basic.img"
+	img {
+		tracks: 77
+		sides: 2
+        trackdata {
+			sector_size: 256
+			sector_range {
+				start_sector: 1
+				sector_count: 26
+			}
+		}
+        trackdata {
+            track: 0
+            side: 0
+			sector_size: 128
+			sector_range {
+				start_sector: 1
+				sector_count: 26
+			}
+		}
+	}
+}
+
+image_writer {
+	filename: "n88basic.img"
+	img {
+		tracks: 77
+		sides: 2
+        trackdata {
+			sector_size: 256
+			sector_range {
+				start_sector: 1
+				sector_count: 26
+			}
+		}
+        trackdata {
+            track: 0
+            side: 0
+			sector_size: 128
+			sector_range {
+				start_sector: 1
+				sector_count: 26
+			}
+		}
+	}
+}
+
+encoder {
+	ibm {
+        trackdata {
+            sector_size: 256
+			track_length_ms: 167
+			clock_rate_khz: 500
+            gap0: 0x36
+            gap2: 22
+            gap3: 0x36
+            use_fm: false
+            idam_byte: 0x5554
+            dam_byte: 0x5545
+            gap_fill_byte: 0x9254
+			sectors {
+				sector: 1
+				sector: 2
+				sector: 3
+				sector: 4
+				sector: 5
+				sector: 6
+				sector: 7
+				sector: 8
+                sector: 9
+                sector: 10
+                sector: 11
+                sector: 12
+                sector: 13
+                sector: 14
+                sector: 15
+                sector: 16
+                sector: 17
+                sector: 18
+                sector: 19
+                sector: 20
+                sector: 21
+                sector: 22
+                sector: 23
+                sector: 24
+                sector: 25
+                sector: 26
+			}
+		}
+        trackdata {
+            sector_size: 128
+			track_length_ms: 167
+			clock_rate_khz: 500
+            use_fm: true
+            gap0: 0x10
+            gap2: 0x09
+            gap3: 0x10
+            idam_byte: 0xf57e
+            dam_byte: 0xf56f
+            gap_fill_byte: 0xffff
+            cylinder: 0
+            head: 0
+		}
+	}
+}
+
+decoder {
+	ibm {}
+}
+
+cylinders {
+	start: 0
+	end: 76
+}
+
+heads {
+	start: 0
+	end: 1
+}


### PR DESCRIPTION
This isn't really intended to be used directly (bare images are
normally .d88 etc) but is useful for testing the FM encoder.
