### PR TITLE
Fix North Star after decoder update

### DIFF
--- a/arch/northstar/decoder.cc
+++ b/arch/northstar/decoder.cc
@@ -127,13 +127,11 @@ public:
 
 		if (matcher == &MFM_PATTERN) {
 			_sectorType = SECTOR_TYPE_MFM;
-			readRawBits(48);
 			return SECTOR_RECORD;
 		}
 
 		if (matcher == &FM_PATTERN) {
 			_sectorType = SECTOR_TYPE_FM;
-			readRawBits(48);
 			return SECTOR_RECORD;
 		}
 
@@ -154,6 +152,8 @@ public:
 			payloadSize = NORTHSTAR_PAYLOAD_SIZE_SD;
 			headerSize = NORTHSTAR_HEADER_SIZE_SD;
 		}
+
+		readRawBits(48);
 
 		auto rawbits = readRawBits(recordSize * 16);
 		auto bytes = decodeFmMfm(rawbits).slice(0, recordSize);

--- a/lib/imagewriter/nsiimagewriter.cc
+++ b/lib/imagewriter/nsiimagewriter.cc
@@ -33,7 +33,7 @@ public:
 		std::cout << fmt::format("Writing {} cylinders, {} sides, {} sectors, {} ({} bytes/sector), {} kB total",
 				geometry.numTracks, geometry.numSides,
 				geometry.numSectors, geometry.sectorSize == 256 ? "SD" : "DD", geometry.sectorSize,
-				geometry.numTracks * geometry.sectorSize / 1024)
+				geometry.numTracks * geometry.numSides * geometry.numSectors * geometry.sectorSize / 1024)
 				<< std::endl;
 
 		std::ofstream outputFile(_config.filename(), std::ios::out | std::ios::binary);


### PR DESCRIPTION
Similar to Micropolis, the North Star decoder was broken by the PLL update.

Fix it and also fix the image size output in the informational message in nsiimagewriter.

Here are [example North Star flux files](https://www.dropbox.com/s/eks28s8dwsal04a/northstar_flux.zip?dl=0)

There is one each of 87.5K SSSD, 175K SSDD, 350K DSDD.

Thanks,
Howard
