### PR TITLE
Fix a small typo in proto.cc

### DIFF
--- a/lib/proto.cc
+++ b/lib/proto.cc
@@ -141,11 +141,13 @@ void setProtoFieldFromString(ProtoField& protoField, const std::string& value)
 			static const std::map<std::string, bool> boolvalues = {
 				{ "false", false },
 				{ "f",     false },
+				{ "no",    false },
 				{ "n",     false },
 				{ "0",     false },
 				{ "true",  true },
 				{ "t",     true },
-				{ "n",     true },
+				{ "yes",   true },
+				{ "y",     true },
 				{ "1",     true },
 			};
 


### PR DESCRIPTION
This is most certainly a typo.

Also it could be nice to have the long-forms of "y" and "n" available as possible options as well