### PR TITLE
Windows: Support serial ports > COM9

### DIFF
--- a/lib/usb/serial.cc
+++ b/lib/usb/serial.cc
@@ -18,8 +18,9 @@
 	public:
 		SerialPortImpl(const std::string& name)
 		{
+			std::string dos_name = "\\\\.\\" + name;
 			_handle = CreateFileA(
-				name.c_str(),
+				dos_name.c_str(),
 				/* dwDesiredAccess= */ GENERIC_READ|GENERIC_WRITE,
 				/* dwShareMode= */ 0,
 				/* lpSecurityAttribues= */ nullptr,


### PR DESCRIPTION
Per #393 FluxEngine can not open the serial port when COM port number is greater than COM9.

Windows requires the use of the DOS UNC path name for COM ports greater than COM9.

Fix: Prefix the port name with \\\\.\\
