### PR TITLE
reader: Fix conflicting sector error message.

### DIFF
--- a/lib/reader.cc
+++ b/lib/reader.cc
@@ -52,7 +52,7 @@ static std::set<std::shared_ptr<Sector>> collect_sectors(std::set<std::shared_pt
 			{
 				std::cout << fmt::format(
 						"\n       multiple conflicting copies of sector {} seen; ",
-						std::get<0>(sectorid), std::get<1>(sectorid), std::get<2>(sectorid));
+						std::get<2>(sectorid));
 				replacing->status = replacement->status = Sector::CONFLICT;
 			}
 		}


### PR DESCRIPTION
The conflicting sector error message incorrectly displays the track instead
of the sector in conflict.  Fix by removing unused track and head arguments,
displaying only the sector in conflict.