### PR TITLE
Victor9k Double Sided Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ at least, check the CRC so what data's there is probably good.
 | [Micropolis](doc/disk-micropolis.md)     |  🦄   |        | Micropolis 100tpi drives |
 | [Northstar](doc/disk-northstar.md)       |  🦖   |   🦖   | 5.25" hard sectors |
 | [TI DS990 FD1000](doc/disk-tids990.md)   |  🦄   |  🦄    | 8" |
-| [Victor 9000](doc/disk-victor9k.md)      |  🦖   |        | 8" |
+| [Victor 9000](doc/disk-victor9k.md)      |  🦖   |        | 5.25" GCR encoded |
 | [Zilog MCZ](doc/disk-zilogmcz.md)        |  🦖   |        | 8" _and_ hard sectors |
 {: .datatable }
 

--- a/doc/disk-victor9k.md
+++ b/doc/disk-victor9k.md
@@ -16,8 +16,8 @@ the speed zone allocation on head 1 differ from head 0...
 | 1    | 4-15          | 0-7           | 18      | 224.5                |
 | 2    | 16-26         | 8-18          | 17      | 212.2                |
 | 3    | 27-37         | 19-29         | 16      | 199.9                |
-| 4    | 38-48         | 30-40         | 15      | 187.6                |
-| 5    | 49-59         | 41-51         | 14      | 175.3                |
+| 4    | 38-47\*       | 30-39\*       | 15      | 187.6                |
+| 5    | 48-59         | 40-51         | 14      | 175.3                |
 | 6    | 60-70         | 52-62         | 13      | 163.0                |
 | 7    | 71-79         | 63-74         | 12      | 149.6                |
 | 8    |               | 75-79         | 11      | 144.0                |
@@ -26,8 +26,13 @@ the speed zone allocation on head 1 differ from head 0...
 FluxEngine, the disk always spins at 360 rpm, which corresponds to a rotational
 period of 166 ms.)
 
-FluxEngine can read and write the single-sided variant of these. (Double-sided
-will be trivial to do, it's just not done yet.)
+\*The Victor 9000 Hardware Reference Manual has a bug in the documentation 
+and lists Zone 4 as ending with track 48 on head 0 and track 40 on head 1. 
+The above table matches observed data on various disks and the assembly 
+code in the boot loader, which ends Zone 4 with track 47 on head 0 
+and track 39 on Head 1.
+
+FluxEngine can read and write both the single-sided and double-sided variants. 
 
 Reading discs
 -------------
@@ -35,10 +40,14 @@ Reading discs
 Just do:
 
 ```
-fluxengine read victor9k-ss
+fluxengine read <format>
+
 ```
 
-You should end up with an `victor9k.img` which is 627200 bytes long.
+...where `<format>` can be `victor9k_ss` or `victor9k_ds`. 
+
+For `victor9k_ss` you should end up with an `victor9k.img` which is 627200 bytes long. 
+For `victor9k_ds` you should end up with an `victor9k.img` which is 1224192 bytes long.
 
 **Big warning!** The image is triangular, where each track occupies a different
 amount of space. Victor disk images are complicated due to the way the tracks
@@ -50,7 +59,7 @@ Writing discs
 Just do:
 
 ```
-fluxengine read victor9k-ss -i victor9k.img
+fluxengine read victor9k_ss -i victor9k.img
 ```
 
 **Big warning!** This uses the same triangular disk image that reading uses.

--- a/mkninja.sh
+++ b/mkninja.sh
@@ -528,6 +528,7 @@ FORMATS="\
     northstar87 \
     tids990 \
     victor9k_ss \
+    victor9k_ds \
     zilogmcz \
     "
 
@@ -639,6 +640,7 @@ encodedecodetest mac800 scripts/mac800_test.textpb
 encodedecodetest n88basic
 encodedecodetest tids990
 encodedecodetest victor9k_ss
+encodedecodetest victor9k_ds
 
 # vim: sw=4 ts=4 et
 

--- a/src/formats/victor9k_ds.textpb
+++ b/src/formats/victor9k_ds.textpb
@@ -1,0 +1,459 @@
+comment: 'Victor 9000 / Sirius One 1224kB DSHD GCR variable sector)'
+
+image_reader {
+	filename: "victor9k_ds.img"
+	img {
+		tracks: 80
+		sides: 2
+		trackdata {
+			sector_size: 512
+			sector_range {
+				start_sector: 0
+			}
+		}
+		trackdata {
+		    side: 0
+			track: 0
+			up_to_track: 3
+			sector_range {
+				sector_count: 19
+			}
+		}
+		trackdata {
+		    side: 0
+			track: 4
+			up_to_track: 15
+			sector_range {
+				sector_count: 18
+			}
+		}
+		trackdata {
+		    side: 0
+			track: 16
+			up_to_track: 26
+			sector_range {
+				sector_count: 17
+			}
+		}
+		trackdata {
+		    side: 0
+			track: 27
+			up_to_track: 37
+			sector_range {
+				sector_count: 16
+			}
+		}
+		trackdata {
+		    side: 0
+			track: 38
+			up_to_track: 47
+			sector_range {
+				sector_count: 15
+			}
+		}
+		trackdata {
+		    side: 0
+			track: 48
+			up_to_track: 59
+			sector_range {
+				sector_count: 14
+			}
+		}
+		trackdata {
+		    side: 0
+			track: 60
+			up_to_track: 70
+			sector_range {
+				sector_count: 13
+			}
+		}
+		trackdata {
+		    side: 0
+			track: 71
+			up_to_track: 79
+			sector_range {
+				sector_count: 12
+			}
+		}
+		trackdata {
+			side: 1
+			track: 0
+			up_to_track: 7
+			sector_range {
+				sector_count: 18
+			}
+		}
+		trackdata {
+			side: 1
+			track: 8
+			up_to_track: 18
+			sector_range {
+				sector_count: 17
+			}
+		}
+		trackdata {
+			side: 1
+			track: 19
+			up_to_track: 29
+			sector_range {
+				sector_count: 16
+			}
+		}
+		trackdata {
+			side: 1
+			track: 30
+			up_to_track: 39
+			sector_range {
+				sector_count: 15
+			}
+		}
+		trackdata {
+			side: 1
+			track: 40
+			up_to_track: 51
+			sector_range {
+				sector_count: 14
+			}
+		}
+		trackdata {
+			side: 1
+			track: 52
+			up_to_track: 62
+			sector_range {
+				sector_count: 13
+			}
+		}
+		trackdata {
+			side: 1
+			track: 63
+			up_to_track: 74
+			sector_range {
+				sector_count: 12
+			}
+		}
+		trackdata {
+			side: 1
+			track: 75
+			up_to_track: 79
+			sector_range {
+				sector_count: 11
+			}
+		}
+	}
+}
+
+image_writer {
+	filename: "victor9k_ds.img"
+	img {
+		tracks: 80
+		sides: 2
+		trackdata {
+			sector_size: 512
+			sector_range {
+				start_sector: 0
+			}
+		}
+		trackdata {
+			side: 0
+			track: 0
+			up_to_track: 3
+			sector_range {
+				sector_count: 19
+			}
+		}
+		trackdata {
+			side: 0
+			track: 4
+			up_to_track: 15
+			sector_range {
+				sector_count: 18
+			}
+		}
+		trackdata {
+			side: 0
+			track: 16
+			up_to_track: 26
+			sector_range {
+				sector_count: 17
+			}
+		}
+		trackdata {
+			side: 0
+			track: 27
+			up_to_track: 37
+			sector_range {
+				sector_count: 16
+			}
+		}
+		trackdata {
+			side: 0
+			track: 38
+			up_to_track: 47
+			sector_range {
+				sector_count: 15
+			}
+		}
+		trackdata {
+			side: 0
+			track: 48
+			up_to_track: 59
+			sector_range {
+				sector_count: 14
+			}
+		}
+		trackdata {
+			side: 0
+			track: 60
+			up_to_track: 70
+			sector_range {
+				sector_count: 13
+			}
+		}
+		trackdata {
+			side: 0
+			track: 71
+			up_to_track: 79
+			sector_range {
+				sector_count: 12
+			}
+		}
+		trackdata {
+			side: 1
+			track: 0
+			up_to_track: 7
+			sector_range {
+				sector_count: 18
+			}
+		}
+		trackdata {
+			side: 1
+			track: 8
+			up_to_track: 18
+			sector_range {
+				sector_count: 17
+			}
+		}
+		trackdata {
+			side: 1
+			track: 19
+			up_to_track: 29
+			sector_range {
+				sector_count: 16
+			}
+		}
+		trackdata {
+			side: 1
+			track: 30
+			up_to_track: 39
+			sector_range {
+				sector_count: 15
+			}
+		}
+		trackdata {
+			side: 1
+			track: 40
+			up_to_track: 51
+			sector_range {
+				sector_count: 14
+			}
+		}
+		trackdata {
+			side: 1
+			track: 52
+			up_to_track: 62
+			sector_range {
+				sector_count: 13
+			}
+		}
+		trackdata {
+			side: 1
+			track: 63
+			up_to_track: 74
+			sector_range {
+				sector_count: 12
+			}
+		}
+		trackdata {
+			side: 1
+			track: 75
+			up_to_track: 79
+			sector_range {
+				sector_count: 11
+			}
+		}
+	}
+}
+
+encoder {
+	victor9k {
+		trackdata {
+			original_data_rate_khz: 500
+			post_index_gap_us: 1000.0
+			pre_header_sync_bits: 120
+			post_header_gap_bits: 48
+			pre_data_sync_bits: 40
+			post_data_gap_bits: 200
+		}
+		trackdata {
+			head: 0
+			min_cylinder: 0
+			max_cylinder: 3
+			original_period_ms: 237.9
+			sector_range {
+				start_sector: 0
+				sector_count: 19
+			}
+		}
+		trackdata {
+			head: 0
+			min_cylinder: 4
+			max_cylinder: 15
+			original_period_ms: 224.5
+			sector_range {
+				sector_count: 18
+			}
+		}
+		trackdata {
+			head: 0
+			min_cylinder: 16
+			max_cylinder: 26
+			original_period_ms: 212.2
+			sector_range {
+				sector_count: 17
+			}
+		}
+		trackdata {
+			head: 0
+			min_cylinder: 27
+			max_cylinder: 37
+			original_period_ms: 199.9
+			sector_range {
+				sector_count: 16
+			}
+		}
+		trackdata {
+			head: 0
+			min_cylinder: 38
+			max_cylinder: 47
+			original_period_ms: 187.6
+			sector_range {
+				sector_count: 15
+			}
+		}
+		trackdata {
+			head: 0
+			min_cylinder: 48
+			max_cylinder: 59
+			original_period_ms: 175.3
+			sector_range {
+				sector_count: 14
+			}
+		}
+		trackdata {
+			head: 0
+			min_cylinder: 60
+			max_cylinder: 70
+			original_period_ms: 163.0
+			sector_range {
+				sector_count: 13
+			}
+		}
+		trackdata {
+			head: 0
+			min_cylinder: 71
+			max_cylinder: 79
+			original_period_ms: 149.6
+			sector_range {
+				sector_count: 12
+			}
+		}
+		trackdata {
+			head: 1
+			min_cylinder: 0
+			max_cylinder: 7
+			original_period_ms: 224.5
+			sector_range {
+				start_sector: 0
+				sector_count: 18
+			}
+		}
+		trackdata {
+			head: 1
+			min_cylinder: 8
+			max_cylinder: 18
+			original_period_ms: 212.2
+			sector_range {
+				sector_count: 17
+			}
+		}
+		trackdata {
+			head: 1
+			min_cylinder: 19
+			max_cylinder: 29
+			original_period_ms: 199.9
+			sector_range {
+				sector_count: 16
+			}
+		}
+		trackdata {
+			head: 1
+			min_cylinder: 30
+			max_cylinder: 39
+			original_period_ms: 187.6
+			sector_range {
+				sector_count: 15
+			}
+		}
+		trackdata {
+			head: 1
+			min_cylinder: 40
+			max_cylinder: 51
+			original_period_ms: 175.3
+			sector_range {
+				sector_count: 14
+			}
+		}
+		trackdata {
+			head: 1
+			min_cylinder: 52
+			max_cylinder: 62
+			original_period_ms: 163.0
+			sector_range {
+				sector_count: 13
+			}
+		}
+		trackdata {
+			head: 1
+			min_cylinder: 63
+			max_cylinder: 74
+			original_period_ms: 149.6
+			sector_range {
+				sector_count: 12
+			}
+		}
+		trackdata {
+			head: 1
+			min_cylinder: 75
+			max_cylinder: 79
+			original_period_ms: 144.0
+			sector_range {
+				sector_count: 11
+			}
+		}
+	}
+}
+
+decoder {
+	victor9k {}
+}
+
+cylinders {
+	start: 0
+	end: 79
+}
+
+heads {
+	start: 0
+	end: 1
+}
+

--- a/src/formats/victor9k_ss.textpb
+++ b/src/formats/victor9k_ss.textpb
@@ -41,13 +41,13 @@ image_reader {
 		}
 		trackdata {
 			track: 38
-			up_to_track: 48
+			up_to_track: 47
 			sector_range {
 				sector_count: 15
 			}
 		}
 		trackdata {
-			track: 49
+			track: 48
 			up_to_track: 59
 			sector_range {
 				sector_count: 14
@@ -111,13 +111,13 @@ image_writer {
 		}
 		trackdata {
 			track: 38
-			up_to_track: 48
+			up_to_track: 47
 			sector_range {
 				sector_count: 15
 			}
 		}
 		trackdata {
-			track: 49
+			track: 48
 			up_to_track: 59
 			sector_range {
 				sector_count: 14
@@ -190,7 +190,7 @@ encoder {
 		trackdata {
 			head: 0
 			min_cylinder: 38
-			max_cylinder: 48
+			max_cylinder: 47
 			original_period_ms: 187.6
 			sector_range {
 				sector_count: 15
@@ -198,7 +198,7 @@ encoder {
 		}
 		trackdata {
 			head: 0
-			min_cylinder: 49
+			min_cylinder: 48
 			max_cylinder: 59
 			original_period_ms: 175.3
 			sector_range {


### PR DESCRIPTION
Hi David,
Thanks for your help earlier. Here's a cleaner re-take on Victor9k double sided disks. I spent a lot of time iterating through what seemed like a bug in the encoder/decoder but was really a demonstration of my lack of bit-shifting skills. 

One note, I'm making an intentional change with track 48. The documentation shows it in zone 4 with 15 sectors and a speed of 187.6 original_period_ms. It actually is in zone 5 with 14 sectors and a speed of 175.3. I'm basing that off the zone organization I'm seeing in the BIOS and the format.com code. The mame code also makes this same correction to what's a bug in the documentation. I've reflected that change on the single sided disks also. 

This all seems to work fine when reading physical media to .img files and .flux files. I can then translate those files back and forth between each other in a reliable manner on my hard drive. I still, however, get errors when I try to write the .img file back out to a physical floppy. This happens on the master branch as well as the victor9k branch before my changes. I'll keep playing with that issue and will hopefully have a separate PR for you on that too.

