### PR TITLE
add generic gw-compatible support

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -53,3 +53,12 @@ jobs:
       run: |
         make
 
+    - name: zip
+      run: |
+        zip -9 fluxengine.zip fluxengine.exe brother120tool.exe brother240tool.exe FluxEngine.cydsn/CortexM3/ARM_GCC_541/Release/FluxEngine.hex
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.event.repository.name }}.${{ github.sha }}
+        path: fluxengine.zip

--- a/lib/usb/greaseweazleusb.cc
+++ b/lib/usb/greaseweazleusb.cc
@@ -131,7 +131,7 @@ public:
                     .write_8(CMD_READ_FLUX)
                     .write_8(cmd.size())
                     .write_le32(0) //ticks default value (guessed)
-                    .write_le32(2);//guessed
+                    .write_le16(2);//revolutions
                 do_command(cmd);
             }
         }

--- a/lib/usb/serial.cc
+++ b/lib/usb/serial.cc
@@ -45,8 +45,16 @@
 			COMMTIMEOUTS commtimeouts = {0};
 			commtimeouts.ReadIntervalTimeout = 100;
 			SetCommTimeouts(_handle, &commtimeouts);
+            
+			if (!EscapeCommFunction(_handle, CLRDTR))
+			  Error() << fmt::format("Couldn't clear DTR: {}",
+                                     get_last_error_string());
+			Sleep(200);
+			if (!EscapeCommFunction(_handle, SETDTR))
+			  Error() << fmt::format("Couldn't set DTR: {}",
+                                     get_last_error_string());
 
-			PurgeComm(_handle, PURGE_RXABORT|PURGE_RXCLEAR|PURGE_TXABORT|PURGE_TXCLEAR);
+            PurgeComm(_handle, PURGE_RXABORT|PURGE_RXCLEAR|PURGE_TXABORT|PURGE_TXCLEAR);
 		}
 
 		~SerialPortImpl() override

--- a/lib/usb/usb.cc
+++ b/lib/usb/usb.cc
@@ -69,7 +69,9 @@ USB* get_usb_impl()
 			return createGreaseWeazleUsb(candidate->serialPort, config.usb().greaseweazle());
 
 		default:
-			Error() << "internal";
+			std::cerr << fmt::format("Using Unknown GW Compatible {} on {}\n", candidate->serial, candidate->serialPort);
+			GreaseWeazleProto gwconfig = config.usb().greaseweazle();
+			return createGreaseWeazleUsb(candidate->serialPort, gwconfig );
 	}
 }
 

--- a/lib/usb/usbfinder.cc
+++ b/lib/usb/usbfinder.cc
@@ -45,5 +45,30 @@ std::vector<std::unique_ptr<CandidateDevice>> findUsbDevices(const std::set<uint
 		}
 	}
 
+    if (candidates.size() == 0) {
+      for (const auto& it : libusbp::list_connected_devices())
+        {
+          auto candidate = std::make_unique<CandidateDevice>();
+          candidate->device = it;
+          uint32_t id = (it.get_vendor_id() << 16) | it.get_product_id();
+          candidate->id = id;
+          candidate->serial = get_serial_number(it);
+          printf("USB ID %04x %04x: ", it.get_vendor_id(), it.get_product_id());
+          try
+            {
+              libusbp::serial_port port(candidate->device, 0, true);
+              candidate->serialPort = port.get_name();
+              printf("generic serialPort found\n");
+              candidates.push_back(std::move(candidate));
+            }
+          catch(const libusbp::error & error)
+            {
+              // not a serial port!
+              printf("not a port!\n");
+              continue;
+            }
+
+		}
+	}
 	return candidates;
 }


### PR DESCRIPTION
hiya! im making a generic arduino-compatible floppy disk read/write library and one of the modes is 'greaseweazle compatibility' - this PR makes it so that fluxengine can successfully detect USB CDC serial ports when there is no exact VID/PID match, fixes a small packing bug in readflux, and also makes generic CDC windows 'activate' by enabling the DTR line. i also added zip upload on PR so folks can test without a release/build.

1) update CI to add zip on commit for quick testing
2) fix gw readflux command (should be 8 bytes long but was packed as 10)
3) add support for non-gw VID/PID (generic serial port that is gw compatible)
4) manually set/clear DTR on serial port devices - this seems to be essential for tinyusb/arduino CDC

not tested with a gw but ought not to have broken anything!

```
     Tracks -> 1         2         3
H.SS 0123456789012345678901234567890123456789
0. 1 ........................................
0. 2 ........................................
0. 3 ........................................
0. 4 ........................................
0. 5 ........................................
0. 6 ........................................
0. 7 ........................................
0. 8 ........................................
0. 9 ........................................
1. 1 ........................................
1. 2 ........................................
1. 3 ........................................
1. 4 ........................................
1. 5 ........................................
1. 6 ........................................
1. 7 ........................................
1. 8 ........................................
1. 9 ........................................
Good sectors: 720/720 (100%)
Missing sectors: 0/720 (0%)
Bad sectors: 0/720 (0%)
IMG: wrote 40 tracks, 2 sides, 360 kB total
```