### PR TITLE
Add option to rescale flux source pulses.

### DIFF
--- a/doc/using.md
+++ b/doc/using.md
@@ -348,13 +348,15 @@ behaviour.
 	useful for using very old drives with FluxEngine itself. If you use this
 	option, then any index marks in the sampled flux are, of course, garbage.
   
-  - `--flux_sink.rescale=X`
+  - `--flux_source.rescale=X, --flux_sink.rescale=X`
   
-  When writing a floppy on a drive that doesn't match the source file rpm,
-  the flux periods can be scaled to compensate. For example, to write
-  a PC-98 1.2MB (360rpm) floppy using a 300rpm floppy drive:
+  When reading or writing a floppy on a drive that doesn't match the
+  original drive RPM, the flux periods can be scaled to compensate.
   
-  `--flux_sink.rescale=1.2`
+  For example, to read or write a PC-98 1.2MB (360rpm) floppy using a 300rpm
+  floppy drive:
+  
+  `--flux_source.rescale=1.2 --flux_sink.rescale=1.2`
 
 ## Visualisation
 

--- a/lib/fluxsource/fluxsource.proto
+++ b/lib/fluxsource/fluxsource.proto
@@ -39,6 +39,7 @@ message Fl2FluxSourceProto {
 }
 
 message FluxSourceProto {
+	optional double rescale = 9 [ default = 1.0, (help) = "amount to divide pulse periods by" ];
 	oneof source {
 		string fluxfile = 1 [default = "name of source flux file"];
 		HardwareFluxSourceProto drive = 2;

--- a/lib/reader.cc
+++ b/lib/reader.cc
@@ -25,6 +25,7 @@ static std::shared_ptr<Fluxmap> readFluxmap(FluxSource& fluxsource, unsigned cyl
 {
 	std::cout << fmt::format("{0:>3}.{1}: ", cylinder, head) << std::flush;
 	std::shared_ptr<Fluxmap> fluxmap = fluxsource.readFlux(cylinder, head);
+	fluxmap->rescale(1.0/config.flux_source().rescale());
 	std::cout << fmt::format(
 		"{0:.0} ms in {1} bytes\n",
             fluxmap->duration()/1e6,


### PR DESCRIPTION
This actually scales by the reciprotal of the flux sink, to
allow the same value to be set for both options.
