### PR TITLE
Improve d64 handling

### DIFF
--- a/lib/imagereader/d64imagereader.cc
+++ b/lib/imagereader/d64imagereader.cc
@@ -9,6 +9,14 @@
 #include <iostream>
 #include <fstream>
 
+enum {
+    SIZE_35T = 683*256,
+    SIZE_35T_ERRORS = 683*257,
+    SIZE_40T = 768*256,
+    SIZE_40T_ERRORS = 768*257,
+};
+
+
 class D64ImageReader : public ImageReader
 {
 public:
@@ -35,7 +43,25 @@ public:
 		unsigned numCylinders = 39;
 		unsigned numHeads = 1;
 		unsigned numSectors = 0;
+        bool errors = false;
 
+        switch(inputFileSize) {
+            case SIZE_35T_ERRORS:
+                errors = true;
+                [[fallthrough]];
+            case SIZE_35T:
+                numCylinders = 34;
+                break;
+            case SIZE_40T_ERRORS:
+                errors = true;
+                [[fallthrough]];
+            case SIZE_40T:
+                break;
+
+            default:
+                Error() << fmt::format("Invalid d64 file size {} bytes",
+                            inputFileSize);
+        }
 		std::cout << "reading D64 image\n"
 		          << fmt::format("{} cylinders, {} heads\n",
 				  		numCylinders, numHeads);

--- a/mkninja.sh
+++ b/mkninja.sh
@@ -318,13 +318,18 @@ encodedecodetest() {
     format=$1
     shift
 
+    args="$*"
+    case "${1-}" in
+    ([0-9]*) shift
+    esac
+
     echo "build $OBJDIR/$format.encodedecode.flux.stamp : encodedecode | fluxengine$EXTENSION scripts/encodedecodetest.sh $*"
     echo "    format=$format"
-    echo "    configs=$*"
+    echo "    configs=$args"
     echo "    fluxx=flux"
     echo "build $OBJDIR/$format.encodedecode.scp.stamp : encodedecode | fluxengine$EXTENSION scripts/encodedecodetest.sh $*"
     echo "    format=$format"
-    echo "    configs=$*"
+    echo "    configs=$args"
     echo "    fluxx=scp"
 }
 
@@ -626,7 +631,7 @@ encodedecodetest atarist800
 encodedecodetest atarist820
 encodedecodetest brother120
 encodedecodetest brother240
-encodedecodetest commodore1541 scripts/commodore1541_test.textpb
+encodedecodetest commodore1541 $((768*256)) scripts/commodore1541_test.textpb
 encodedecodetest commodore1581
 encodedecodetest hp9121
 encodedecodetest ibm1200_525

--- a/scripts/encodedecodetest.sh
+++ b/scripts/encodedecodetest.sh
@@ -10,8 +10,13 @@ shift
 shift
 
 trap "rm -f $srcfile $fluxfile $destfile" EXIT
+bs=1048576
+count=2
+case "${1-}" in
+([0-9]*) bs=$1; count=1; shift;
+esac
 
-dd if=/dev/urandom of=$srcfile bs=1048576 count=2 2>&1
+dd if=/dev/urandom of=$srcfile bs=$bs count=$count 2>&1
 
 ./fluxengine write $format -i $srcfile -d $fluxfile "$@"
 ./fluxengine read $format -s $fluxfile -o $destfile "$@"


### PR DESCRIPTION
I was trying to use fluxengine d64 files with vice x64, but I found that when there were error sectors the disk image written out simply omitted them.

This caused vice to refuse to recognize the d64 file, because only a few specific file lengths are accepted. This made vice reject the floppy disk image with "unknown gcr version".

Instead, when a sector is not present that should have been, write out zeros and append an error bitmap.

I have used several pieces of software archived from floppy disks (using the adafruit prototype floppy featherwing) in x64 with this patch: Jumpman, Alf, and "Pro Financial Organizer" (hey, when you borrow whatever floppies a friend will lend you, you get weird stuff).

![Screenshot_2022-01-24_20-41-47](https://user-images.githubusercontent.com/1517291/150902453-9b343ad5-e29e-4baf-8181-ca98310029d5.png)