### PR TITLE
Don't crash when trying to read flux from a fl2 file where there isn't any.

### DIFF
--- a/lib/fluxsource/fl2fluxsource.cc
+++ b/lib/fluxsource/fl2fluxsource.cc
@@ -31,7 +31,7 @@ public:
 				return std::make_unique<Fluxmap>(track.flux());
 		}
 
-		return std::unique_ptr<Fluxmap>();
+		return std::make_unique<Fluxmap>();
     }
 
     void recalibrate() {}


### PR DESCRIPTION
Fixes: #429 