### PR TITLE
Don't use signed values for track/sector/side values

### DIFF
--- a/lib/sector.h
+++ b/lib/sector.h
@@ -34,11 +34,11 @@ public:
     nanoseconds_t headerEndTime = 0;
     nanoseconds_t dataStartTime = 0;
     nanoseconds_t dataEndTime = 0;
-    int physicalCylinder = 0;
-    int physicalHead = 0;
-    int logicalTrack = 0;
-    int logicalSide = 0;
-    int logicalSector = 0;
+    unsigned physicalCylinder = 0;
+    unsigned physicalHead = 0;
+    unsigned logicalTrack = 0;
+    unsigned logicalSide = 0;
+    unsigned logicalSector = 0;
     Bytes data;
 	std::vector<std::shared_ptr<Record>> records;
 

--- a/src/formats/brother120.textpb
+++ b/src/formats/brother120.textpb
@@ -17,7 +17,17 @@ image_reader {
 
 image_writer {
 	filename: "brother120.img"
-	img {}
+	img {
+		tracks: 39
+		sides: 1
+		trackdata {
+			sector_size: 256
+			sector_range {
+				start_sector: 0
+				sector_count: 12
+			}
+		}
+	}
 }
 
 encoder {

--- a/src/formats/brother240.textpb
+++ b/src/formats/brother240.textpb
@@ -17,7 +17,17 @@ image_reader {
 
 image_writer {
 	filename: "brother240.img"
-	img {}
+	img {
+		tracks: 78
+		sides: 1
+		trackdata {
+			sector_size: 256
+			sector_range {
+				start_sector: 0
+				sector_count: 12
+			}
+		}
+	}
 }
 
 encoder {


### PR DESCRIPTION
This can cause glitchiness with out-of-bound values, leading in total output failure.

Fixes #434 