### PR TITLE
Fix some autoconfigure issues.

### DIFF
--- a/lib/imagereader/d88imagereader.cc
+++ b/lib/imagereader/d88imagereader.cc
@@ -165,6 +165,21 @@ public:
         const Geometry& geometry = image->getGeometry();
         std::cout << fmt::format("D88: read {} tracks, {} sides\n",
                         geometry.numTracks, geometry.numSides);
+
+		if (!config.has_heads())
+		{
+			auto* heads = config.mutable_heads();
+			heads->set_start(0);
+			heads->set_end(geometry.numSides - 1);
+		}
+
+		if (!config.has_cylinders())
+		{
+			auto* cylinders = config.mutable_cylinders();
+			cylinders->set_start(0);
+			cylinders->set_end(geometry.numTracks - 1);
+		}
+
         return image;
     }
 

--- a/lib/imagereader/dimimagereader.cc
+++ b/lib/imagereader/dimimagereader.cc
@@ -136,6 +136,21 @@ public:
         std::cout << fmt::format("DIM: read {} tracks, {} sides, {} kB total\n",
                         geometry.numTracks, geometry.numSides,
 						((int)inputFile.tellg() - 256) / 1024);
+
+		if (!config.has_heads())
+		{
+			auto* heads = config.mutable_heads();
+			heads->set_start(0);
+			heads->set_end(geometry.numSides - 1);
+		}
+
+		if (!config.has_cylinders())
+		{
+			auto* cylinders = config.mutable_cylinders();
+			cylinders->set_start(0);
+			cylinders->set_end(geometry.numTracks - 1);
+		}
+
         return image;
 	}
 

--- a/lib/imagereader/dimimagereader.cc
+++ b/lib/imagereader/dimimagereader.cc
@@ -129,6 +129,8 @@ public:
                     Error() << fmt::format("DIM: unknown media byte 0x%02x, could not determine write profile automatically", mediaByte);
                     break;
             }
+
+			config.mutable_decoder()->mutable_ibm();
         }
 
 		image->calculateSize();

--- a/lib/imagereader/fdiimagereader.cc
+++ b/lib/imagereader/fdiimagereader.cc
@@ -109,6 +109,21 @@ public:
         std::cout << fmt::format("FDI: read {} tracks, {} sides, {} kB total\n",
                         geometry.numTracks, geometry.numSides,
 						((int)inputFile.tellg() - headerSize) / 1024);
+
+		if (!config.has_heads())
+		{
+			auto* heads = config.mutable_heads();
+			heads->set_start(0);
+			heads->set_end(geometry.numSides - 1);
+		}
+
+		if (!config.has_cylinders())
+		{
+			auto* cylinders = config.mutable_cylinders();
+			cylinders->set_start(0);
+			cylinders->set_end(geometry.numTracks - 1);
+		}
+		
         return image;
 	}
 


### PR DESCRIPTION
- the DIM image reader now sets up the decoder, allowing writes to be verified
- the readers which do autoconfiguration will set the head and cylinder ranges where appropriate

Fixes: #424