### PR TITLE
MX decoder fix

### DIFF
--- a/src/formats/mx.textpb
+++ b/src/formats/mx.textpb
@@ -5,6 +5,14 @@ image_writer {
 	img {}
 }
 
+flux_source {
+	drive {
+		sync_with_index: true
+		high_density: false
+		revolutions: 3
+	}
+}
+
 decoder {
 	mx {}
 }


### PR DESCRIPTION
Hi there.
I never had a chance to use a DVK in person, but it turns out I apparently have quite a few DVK MX floppies - I bought a box of mystery 5.25"s a decade ago to reformat and use on my Speccy, C64, old IBMs and stuff.
I ended up not using much of them, and recently got curious to what's on the rest of them and made myself a Greaseweazle with a Blue Pill board.

I'll admit that don't have a rock solid 100% reliable way of ensuring the decoding correctness as I don't own a real DVK with MX controller;
But using [dsk-to-hfe script I found in HxC thread linked on your MX page](https://torlus.com/floppy/forum/viewtopic.php?t=1384), and HxC floppy emulator software to visualize disk images, I can assume I didn't make anything worse - now it actually produces not just any, but good disk images for me - it didn't do that before (which made me wonder if this decoder was ever used at all successfully by anyone).

Example:
![1 (EC5281 DSQD) scp](https://user-images.githubusercontent.com/13421195/151585252-bdff7f83-6037-47d8-8a1a-76a16ae65892.png)

This is how the flux image of a disk looks like, straight from the disk itself.

![hfe](https://user-images.githubusercontent.com/13421195/151585406-d318a321-ab23-471f-b276-4dacbc8472fb.png)

And this cleaned-up image was produced by running decoded (from flux above) .img through the Perl script that produces .hfe for the floppy emulator.

Version before those changes didn't work for me - decoder just produced a tiny 5KB image with 1 cylinder and 2 heads, since not all MX disks have track numbers embedded into tracks, aside from other things, rest of which I attempted to describe in detail in my commit message.

As of now, I successfully recovered around 15 MX floppies with this version.

Feel free to ask any questions.
Thank you :)
