### PR TITLE
fix 2 byte pack for revolution count

### DIFF
--- a/lib/usb/greaseweazleusb.cc
+++ b/lib/usb/greaseweazleusb.cc
@@ -302,7 +302,7 @@ public:
                     .write_8(CMD_READ_FLUX)
                     .write_8(cmd.size())
                     .write_le32((readTime + (synced ? _revolutions : 0)) / _clock)
-                    .write_le32(0);
+                    .write_le16(0);
                 do_command(cmd);
             }
         }


### PR DESCRIPTION
hiya, in greaseweazle, this is packed as a `H` (2 byte) not `I` (4 byte) value
https://github.com/keirf/greaseweazle/blob/ffdecb17bc5baf594921972c684999ff1d8eaf73/scripts/greaseweazle/usb.py#L396