### PR TITLE
add dsk format which is basically diskcopy minus the 0x54 byte header

### DIFF
--- a/lib/imagereader/dskimagereader.cc
+++ b/lib/imagereader/dskimagereader.cc
@@ -1,0 +1,135 @@
+#include "globals.h"
+#include "flags.h"
+#include "sector.h"
+#include "imagereader/imagereader.h"
+#include "image.h"
+#include "lib/config.pb.h"
+#include "fmt/format.h"
+#include <algorithm>
+#include <iostream>
+#include <fstream>
+
+class DSKImageReader : public ImageReader
+{
+public:
+	DSKImageReader(const ImageReaderProto& config):
+		ImageReader(config)
+	{}
+
+	std::unique_ptr<Image> readImage()
+	{
+        std::ifstream inputFile(_config.filename(), std::ios::in | std::ios::binary);
+        if (!inputFile.is_open())
+            Error() << "cannot open input file";
+
+        // determine filesize
+        inputFile.seekg(0, inputFile.beg);
+        uint32_t begin = inputFile.tellg();
+        inputFile.seekg(0, inputFile.end);
+        uint32_t end = inputFile.tellg();
+        uint32_t dataSize = (end-begin);
+        inputFile.seekg(0, inputFile.beg);
+        std::cout << fmt::format("{} byte file \n", dataSize);
+
+		Bytes data;
+		data.writer() += inputFile;
+		ByteReader br(data);
+
+		unsigned numCylinders = 80;
+		unsigned numHeads = 2;
+		unsigned numSectors = 0;
+		bool mfm = false;
+
+        unsigned encoding = 1;
+
+		switch (encoding)
+		{
+			case 0: /* GCR CLV 400kB */
+				numHeads = 1;
+				break;
+
+			case 1: /* GCR CLV 800kB */
+				break;
+
+			case 2: /* MFM CAV 720kB */
+				numSectors = 9;
+				mfm = true;
+				break;
+
+			case 3: /* MFM CAV 1440kB */
+				numSectors = 18;
+				mfm = true;
+				break;
+
+			default:
+				Error() << fmt::format("don't understand DSK disks of type {}", encoding);
+		}
+
+		std::cout << "reading DSK image\n"
+		          << fmt::format("{} cylinders, {} heads; {} \n",
+				  		numCylinders, numHeads,
+						mfm ? "MFM" : "GCR");
+
+		auto sectorsPerTrack = [&](int track) -> int
+		{
+			if (mfm)
+				return numSectors;
+
+			if (track < 16)
+				return 12;
+			if (track < 32)
+				return 11;
+			if (track < 48)
+				return 10;
+			if (track < 64)
+				return 9;
+			return 8;
+		};
+
+		uint32_t dataPtr = 0x54;
+		uint32_t tagPtr = dataPtr + dataSize;
+
+        std::unique_ptr<Image> image(new Image);
+        for (int track = 0; track < numCylinders; track++)
+        {
+			int numSectors = sectorsPerTrack(track);
+            for (int head = 0; head < numHeads; head++)
+            {
+                for (int sectorId = 0; sectorId < numSectors; sectorId++)
+                {
+					br.seek(dataPtr);
+					Bytes payload = br.read(512);
+					dataPtr += 512;
+
+					br.seek(tagPtr);
+					Bytes tag = br.read(12);
+					tagPtr += 12;
+
+                    const auto& sector = image->put(track, head, sectorId);
+                    sector->status = Sector::OK;
+                    sector->logicalTrack = sector->physicalCylinder = track;
+                    sector->logicalSide = sector->physicalHead = head;
+                    sector->logicalSector = sectorId;
+                    sector->data.writer().append(payload).append(tag);
+                }
+            }
+        }
+
+		image->setGeometry({
+			.numTracks = numCylinders,
+			.numSides = numHeads,
+			.numSectors = 12,
+			.sectorSize = 512 + 12,
+			.irregular = true
+		});
+        return image;
+	}
+};
+
+std::unique_ptr<ImageReader> ImageReader::createDSKImageReader(
+	const ImageReaderProto& config)
+{
+    return std::unique_ptr<ImageReader>(new DSKImageReader(config));
+}
+
+

--- a/lib/imagereader/imagereader.cc
+++ b/lib/imagereader/imagereader.cc
@@ -32,6 +32,9 @@ std::unique_ptr<ImageReader> ImageReader::create(const ImageReaderProto& config)
 		case ImageReaderProto::kDiskcopy:
 			return ImageReader::createDiskCopyImageReader(config);
 
+        case ImageReaderProto::kDsk:
+			return ImageReader::createDSKImageReader(config);
+
 		case ImageReaderProto::kJv3:
 			return ImageReader::createJv3ImageReader(config);
 
@@ -64,6 +67,7 @@ void ImageReader::updateConfigForFilename(ImageReaderProto* proto, const std::st
 		{".d88",      [&]() { proto->mutable_d88(); }},
 		{".dim",      [&]() { proto->mutable_dim(); }},
 		{".diskcopy", [&]() { proto->mutable_diskcopy(); }},
+		{".dsk",      [&]() { proto->mutable_dsk(); }},
 		{".fdi",      [&]() { proto->mutable_fdi(); }},
 		{".imd",      [&]() { proto->mutable_imd(); }},
 		{".img",      [&]() { proto->mutable_img(); }},

--- a/lib/imagereader/imagereader.h
+++ b/lib/imagereader/imagereader.h
@@ -19,6 +19,7 @@ public:
 public:
     static std::unique_ptr<ImageReader> createD64ImageReader(const ImageReaderProto& config);
     static std::unique_ptr<ImageReader> createDiskCopyImageReader(const ImageReaderProto& config);
+    static std::unique_ptr<ImageReader> createDSKImageReader(const ImageReaderProto& config);
     static std::unique_ptr<ImageReader> createImgImageReader(const ImageReaderProto& config);
     static std::unique_ptr<ImageReader> createJv3ImageReader(const ImageReaderProto& config);
     static std::unique_ptr<ImageReader> createIMDImageReader(const ImageReaderProto& config);

--- a/lib/imagereader/imagereader.proto
+++ b/lib/imagereader/imagereader.proto
@@ -49,6 +49,7 @@ message DimInputProto {}
 message FdiInputProto {}
 message D88InputProto {}
 message NFDInputProto {}
+message DSKInputProto {}
 
 message ImageReaderProto {
 	optional string filename = 1 [(help) = "filename of input sector image"];
@@ -64,6 +65,7 @@ message ImageReaderProto {
 		FdiInputProto fdi = 10;
 		D88InputProto d88 = 11;
         NFDInputProto nfd = 12;
+		DSKInputProto dsk = 13;
 	}
 }
 

--- a/lib/imagewriter/dskimagewriter.cc
+++ b/lib/imagewriter/dskimagewriter.cc
@@ -1,0 +1,135 @@
+#include "globals.h"
+#include "flags.h"
+#include "sector.h"
+#include "imagewriter/imagewriter.h"
+#include "fmt/format.h"
+#include "ldbs.h"
+#include "image.h"
+#include "lib/config.pb.h"
+#include <algorithm>
+#include <iostream>
+#include <fstream>
+
+static const char LABEL[] = "FluxEngine image";
+
+static void write_and_update_checksum(ByteWriter& bw, uint32_t& checksum, const Bytes& data)
+{
+	ByteReader br(data);
+	while (!br.eof())
+	{
+		uint32_t i = br.read_be16();
+		checksum += i;
+		checksum = (checksum >> 1) | (checksum << 31);
+		bw.write_be16(i);
+	}
+}
+
+class DSKImageWriter : public ImageWriter
+{
+public:
+	DSKImageWriter(const ImageWriterProto& config):
+		ImageWriter(config)
+	{}
+
+	void writeImage(const Image& image)
+	{
+		const Geometry& geometry = image.getGeometry();
+
+		bool mfm = false;
+
+		switch (geometry.sectorSize)
+		{
+			case 524:
+				/* GCR disk */
+				break;
+
+			case 512:
+				/* MFM disk */
+				mfm = true;
+				break;
+
+			default:
+				Error() << "this image is not compatible with the DSK format";
+		}
+
+		std::cout << "writing DSK image\n"
+		          << fmt::format("{} tracks, {} sides, {} sectors, {} bytes per sector; {}\n",
+				  		geometry.numTracks, geometry.numSides, geometry.numSectors, geometry.sectorSize,
+						mfm ? "MFM" : "GCR");
+
+		auto sectors_per_track = [&](int track) -> int
+		{
+			if (mfm)
+				return geometry.numSectors;
+
+			if (track < 16)
+				return 12;
+			if (track < 32)
+				return 11;
+			if (track < 48)
+				return 10;
+			if (track < 64)
+				return 9;
+			return 8;
+		};
+
+		Bytes data;
+		ByteWriter bw(data);
+
+		/* Write the actual sector data. */
+
+		uint32_t dataChecksum = 0;
+		uint32_t tagChecksum = 0;
+		uint32_t offset = 0x0;
+		uint32_t sectorDataStart = offset;
+		for (int track = 0; track < geometry.numTracks; track++)
+		{
+			for (int side = 0; side < geometry.numSides; side++)
+			{
+				int sectorCount = sectors_per_track(track);
+				for (int sectorId = 0; sectorId < sectorCount; sectorId++)
+				{
+					const auto& sector = image.get(track, side, sectorId);
+					if (sector)
+					{
+						bw.seek(offset);
+						write_and_update_checksum(bw, dataChecksum, sector->data.slice(0, 512));
+					}
+					offset += 512;
+				}
+			}
+		}
+		uint32_t sectorDataEnd = offset;
+		if (!mfm)
+		{
+			for (int track = 0; track < geometry.numTracks; track++)
+			{
+				for (int side = 0; side < geometry.numSides; side++)
+				{
+					int sectorCount = sectors_per_track(track);
+					for (int sectorId = 0; sectorId < sectorCount; sectorId++)
+					{
+						const auto& sector = image.get(track, side, sectorId);
+						if (sector)
+						{
+							bw.seek(offset);
+							write_and_update_checksum(bw, tagChecksum, sector->data.slice(512, 12));
+						}
+						offset += 12;
+					}
+				}
+			}
+		}
+		uint32_t tagDataEnd = offset;
+
+		data.writeToFile(_config.filename());
+    }
+};
+
+std::unique_ptr<ImageWriter> ImageWriter::createDSKImageWriter(
+	const ImageWriterProto& config)
+{
+    return std::unique_ptr<ImageWriter>(new DSKImageWriter(config));
+}
+
+

--- a/lib/imagewriter/imagewriter.cc
+++ b/lib/imagewriter/imagewriter.cc
@@ -26,6 +26,9 @@ std::unique_ptr<ImageWriter> ImageWriter::create(const ImageWriterProto& config)
 		case ImageWriterProto::kDiskcopy:
 			return ImageWriter::createDiskCopyImageWriter(config);
 
+		case ImageWriterProto::kDsk:
+			return ImageWriter::createDSKImageWriter(config);
+
 		case ImageWriterProto::kNsi:
 			return ImageWriter::createNsiImageWriter(config);
 
@@ -46,6 +49,7 @@ void ImageWriter::updateConfigForFilename(ImageWriterProto* proto, const std::st
 		{".d64",      [&]() { proto->mutable_d64(); }},
 		{".d81",      [&]() { proto->mutable_img(); }},
 		{".diskcopy", [&]() { proto->mutable_diskcopy(); }},
+		{".dsk",      [&]() { proto->mutable_dsk(); }},
 		{".img",      [&]() { proto->mutable_img(); }},
 		{".ldbs",     [&]() { proto->mutable_ldbs(); }},
 		{".nsi",      [&]() { proto->mutable_nsi(); }},

--- a/lib/imagewriter/imagewriter.h
+++ b/lib/imagewriter/imagewriter.h
@@ -16,6 +16,7 @@ public:
 
     static std::unique_ptr<ImageWriter> createD64ImageWriter(const ImageWriterProto& config);
     static std::unique_ptr<ImageWriter> createDiskCopyImageWriter(const ImageWriterProto& config);
+    static std::unique_ptr<ImageWriter> createDSKImageWriter(const ImageWriterProto& config);
     static std::unique_ptr<ImageWriter> createImgImageWriter(const ImageWriterProto& config);
     static std::unique_ptr<ImageWriter> createLDBSImageWriter(const ImageWriterProto& config);
     static std::unique_ptr<ImageWriter> createNsiImageWriter(const ImageWriterProto& config);

--- a/lib/imagewriter/imagewriter.proto
+++ b/lib/imagewriter/imagewriter.proto
@@ -28,6 +28,7 @@ message LDBSOutputProto {
 }
 
 message DiskCopyOutputProto {}
+message DSKOutputProto {}
 message NsiOutputProto {}
 message RawOutputProto {}
 
@@ -40,6 +41,7 @@ message ImageWriterProto {
 		DiskCopyOutputProto diskcopy = 5;
 		NsiOutputProto nsi = 6;
 		RawOutputProto raw = 7;
+		DSKOutputProto dsk = 8;
 	}
 }
 

--- a/mkninja.sh
+++ b/mkninja.sh
@@ -464,6 +464,7 @@ buildlibrary libbackend.a \
     lib/imagereader/d88imagereader.cc \
     lib/imagewriter/d64imagewriter.cc \
     lib/imagewriter/diskcopyimagewriter.cc \
+    lib/imagewriter/dskimagewriter.cc \
     lib/imagewriter/imagewriter.cc \
     lib/imagewriter/imgimagewriter.cc \
     lib/imagewriter/ldbsimagewriter.cc \

--- a/mkninja.sh
+++ b/mkninja.sh
@@ -453,6 +453,7 @@ buildlibrary libbackend.a \
     lib/image.cc \
     lib/imagereader/d64imagereader.cc \
     lib/imagereader/diskcopyimagereader.cc \
+    lib/imagereader/dskimagereader.cc \
     lib/imagereader/imagereader.cc \
     lib/imagereader/imdimagereader.cc \
     lib/imagereader/imgimagereader.cc \


### PR DESCRIPTION
most mac emulators / computers dont like diskcopy format - they prefer dsk there's a converter but it would save a step if dsk's were emitted :)
see https://www.bigmessowires.com/dc2dsk.c
not sure if i did this right, and its a lil hacky, since we don't crop the file, but it does work!

![image](https://user-images.githubusercontent.com/1214161/153062836-94609991-f39a-434e-9528-833bc0cfad9c.png)
