### PR TITLE
Support 84-track SCP files

### DIFF
--- a/lib/fluxsink/scpfluxsink.cc
+++ b/lib/fluxsink/scpfluxsink.cc
@@ -85,6 +85,12 @@ public:
 		trackdataWriter.seekToEnd();
 		int strack = strackno(cylinder, head);
 
+                if (strack >= std::size(_fileheader.track)) {
+                    std::cout << fmt::format("SCP: cannot write track {} head {}, "
+                            "there are not not enough Track Data Headers.\n",
+                            cylinder, head);
+                    return;
+                }
 		ScpTrack trackheader = {0};
 		trackheader.header.track_id[0] = 'T';
 		trackheader.header.track_id[1] = 'R';

--- a/lib/scp.h
+++ b/lib/scp.h
@@ -14,7 +14,7 @@ struct ScpHeader
     uint8_t heads;         // 0 = both, 1 = side 0 only, 2 = side 1 only
     uint8_t resolution;    // 25ns * (resolution+1)
     uint8_t checksum[4];   // of data after this point
-    uint8_t track[165][4]; // track offsets, not necessarily 165
+    uint8_t track[168][4]; // track offsets, not necessarily 168
 };
 
 enum


### PR DESCRIPTION
According to version 2.2 of the [SCP image specification at cbmstuff.com](https://www.cbmstuff.com/downloads/scp/scp_image_specs.txt) the number of Track Data Entries for a floppy can be up to 168, so that up to 84 tracks can be recorded (e.g., fluxengine -c 0-83).
    
> BYTES 0x10-0x2AF (for floppy image files) are a table of longwords with each entry being an offset to a Track Data Header (TDH) for each track that is stored in the image.  The table is always sequential.  There is an entry for every track, with up to 168 entries supported for floppy disks.  This means that floppy disk images of up to 84 tracks with sides 0/1 are possible.

Additionally, instead of segfaulting if a too-large number of tracks (e.g. -c 0-84) is used, print a message and continue.