### PR TITLE
Prevent bad reads on gapless formats.

### DIFF
--- a/arch/aeslanier/decoder.cc
+++ b/arch/aeslanier/decoder.cc
@@ -30,17 +30,14 @@ public:
 		AbstractDecoder(config)
 	{}
 
-    RecordType advanceToNextRecord()
+    nanoseconds_t advanceToNextRecord() override
 	{
-		_sector->clock = _fmr->seekToPattern(SECTOR_PATTERN);
-		if (_fmr->eof() || !_sector->clock)
-			return UNKNOWN_RECORD;
-		return SECTOR_RECORD;
+		return seekToPattern(SECTOR_PATTERN);
 	}
 
     void decodeSectorRecord()
 	{
-		/* Skip ID mark. */
+		/* Skip ID mark (we know it's a AESLANIER_RECORD_SEPARATOR). */
 
 		readRawBits(16);
 

--- a/arch/apple2/decoder.cc
+++ b/arch/apple2/decoder.cc
@@ -78,8 +78,8 @@ public:
 
     void decodeSectorRecord()
 	{
-		/* Skip ID (as we know it's a APPLE2_SECTOR_RECORD). */
-		readRawBits(24);
+		if (readRaw24() != APPLE2_SECTOR_RECORD)
+			return;
 
 		/* Read header. */
 
@@ -98,14 +98,13 @@ public:
 	{
 		/* Check ID. */
 
-		Bytes bytes = toBytes(readRawBits(3*8)).slice(0, 3);
-		if (bytes.reader().read_be24() != APPLE2_DATA_RECORD)
+		if (readRaw24() != APPLE2_DATA_RECORD)
 			return;
 
 		/* Read and decode data. */
 
 		unsigned recordLength = APPLE2_ENCODED_SECTOR_LENGTH + 2;
-		bytes = toBytes(readRawBits(recordLength*8)).slice(0, recordLength);
+		Bytes bytes = toBytes(readRawBits(recordLength*8)).slice(0, recordLength);
 
 		_sector->status = Sector::BAD_CHECKSUM;
 		_sector->data = decode_crazy_data(&bytes[0], _sector->status);

--- a/arch/apple2/decoder.cc
+++ b/arch/apple2/decoder.cc
@@ -71,15 +71,9 @@ public:
 		AbstractDecoder(config)
 	{}
 
-    RecordType advanceToNextRecord()
+    nanoseconds_t advanceToNextRecord() override
 	{
-		const FluxMatcher* matcher = nullptr;
-		_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
-		if (matcher == &SECTOR_RECORD_PATTERN)
-			return RecordType::SECTOR_RECORD;
-		if (matcher == &DATA_RECORD_PATTERN)
-			return RecordType::DATA_RECORD;
-		return RecordType::UNKNOWN_RECORD;
+		return seekToPattern(ANY_RECORD_PATTERN);
 	}
 
     void decodeSectorRecord()

--- a/arch/brother/decoder.cc
+++ b/arch/brother/decoder.cc
@@ -66,7 +66,9 @@ public:
 
     void decodeSectorRecord()
 	{
-		readRawBits(32);
+		if (readRaw32() != BROTHER_SECTOR_RECORD)
+			return;
+
 		const auto& rawbits = readRawBits(32);
 		const auto& bytes = toBytes(rawbits).slice(0, 4);
 
@@ -86,7 +88,8 @@ public:
 	
     void decodeDataRecord()
 	{
-		readRawBits(32);
+		if (readRaw32() != BROTHER_DATA_RECORD)
+			return;
 
 		const auto& rawbits = readRawBits(BROTHER_DATA_RECORD_ENCODED_SIZE*8);
 		const auto& rawbytes = toBytes(rawbits).slice(0, BROTHER_DATA_RECORD_ENCODED_SIZE);

--- a/arch/brother/decoder.cc
+++ b/arch/brother/decoder.cc
@@ -59,15 +59,9 @@ public:
 		AbstractDecoder(config)
 	{}
 
-    RecordType advanceToNextRecord()
+    nanoseconds_t advanceToNextRecord() override
 	{
-		const FluxMatcher* matcher = nullptr;
-		_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
-		if (matcher == &SECTOR_RECORD_PATTERN)
-			return RecordType::SECTOR_RECORD;
-		if (matcher == &DATA_RECORD_PATTERN)
-			return RecordType::DATA_RECORD;
-		return RecordType::UNKNOWN_RECORD;
+		return seekToPattern(ANY_RECORD_PATTERN);
 	}
 
     void decodeSectorRecord()

--- a/arch/c64/decoder.cc
+++ b/arch/c64/decoder.cc
@@ -58,15 +58,9 @@ public:
 		AbstractDecoder(config)
 	{}
 
-    RecordType advanceToNextRecord()
+    nanoseconds_t advanceToNextRecord() override
 	{
-		const FluxMatcher* matcher = nullptr;
-		_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
-		if (matcher == &SECTOR_RECORD_PATTERN)
-			return RecordType::SECTOR_RECORD;
-		if (matcher == &DATA_RECORD_PATTERN)
-			return RecordType::DATA_RECORD;
-		return RecordType::UNKNOWN_RECORD;
+		return seekToPattern(ANY_RECORD_PATTERN);
 	}
 
     void decodeSectorRecord()

--- a/arch/c64/decoder.cc
+++ b/arch/c64/decoder.cc
@@ -65,7 +65,8 @@ public:
 
     void decodeSectorRecord()
 	{
-		readRawBits(20);
+		if (readRaw20() != C64_SECTOR_RECORD)
+			return;
 
 		const auto& bits = readRawBits(5*10);
 		const auto& bytes = decode(bits).slice(0, 5);
@@ -80,7 +81,8 @@ public:
 
     void decodeDataRecord()
 	{
-		readRawBits(20);
+		if (readRaw20() != C64_DATA_RECORD)
+			return;
 
 		const auto& bits = readRawBits(259*10);
 		const auto& bytes = decode(bits).slice(0, 259);

--- a/arch/f85/decoder.cc
+++ b/arch/f85/decoder.cc
@@ -67,7 +67,8 @@ public:
 	{
 		/* Skip sync bits and ID byte. */
 
-		readRawBits(24);
+		if (readRaw24() != F85_SECTOR_RECORD)
+			return;
 
 		/* Read header. */
 
@@ -87,7 +88,8 @@ public:
 	{
 		/* Skip sync bits ID byte. */
 
-		readRawBits(24);
+		if (readRaw24() != F85_DATA_RECORD)
+			return;
 
 		const auto& bytes = decode(readRawBits((F85_SECTOR_LENGTH+3)*10))
 			.slice(0, F85_SECTOR_LENGTH+3);

--- a/arch/f85/decoder.cc
+++ b/arch/f85/decoder.cc
@@ -58,15 +58,9 @@ public:
 		AbstractDecoder(config)
 	{}
 
-    RecordType advanceToNextRecord()
+    nanoseconds_t advanceToNextRecord() override
 	{
-		const FluxMatcher* matcher = nullptr;
-		_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
-		if (matcher == &SECTOR_RECORD_PATTERN)
-			return RecordType::SECTOR_RECORD;
-		if (matcher == &DATA_RECORD_PATTERN)
-			return RecordType::DATA_RECORD;
-		return RecordType::UNKNOWN_RECORD;
+		return seekToPattern(ANY_RECORD_PATTERN);
 	}
 
     void decodeSectorRecord()

--- a/arch/fb100/decoder.cc
+++ b/arch/fb100/decoder.cc
@@ -104,13 +104,9 @@ public:
 		AbstractDecoder(config)
 	{}
 
-    RecordType advanceToNextRecord()
+    nanoseconds_t advanceToNextRecord() override
 	{
-		const FluxMatcher* matcher = nullptr;
-		_sector->clock = _fmr->seekToPattern(SECTOR_ID_PATTERN, matcher);
-		if (matcher == &SECTOR_ID_PATTERN)
-			return RecordType::SECTOR_RECORD;
-		return RecordType::UNKNOWN_RECORD;
+		return seekToPattern(SECTOR_ID_PATTERN);
 	}
 
     void decodeSectorRecord()

--- a/arch/macintosh/decoder.cc
+++ b/arch/macintosh/decoder.cc
@@ -129,15 +129,9 @@ public:
 		AbstractDecoder(config)
 	{}
 
-    RecordType advanceToNextRecord()
+    nanoseconds_t advanceToNextRecord() override
 	{
-		const FluxMatcher* matcher = nullptr;
-		_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
-		if (matcher == &SECTOR_RECORD_PATTERN)
-			return SECTOR_RECORD;
-		if (matcher == &DATA_RECORD_PATTERN)
-			return DATA_RECORD;
-		return UNKNOWN_RECORD;
+		return seekToPattern(ANY_RECORD_PATTERN);
 	}
 
     void decodeSectorRecord()

--- a/arch/macintosh/decoder.cc
+++ b/arch/macintosh/decoder.cc
@@ -136,8 +136,8 @@ public:
 
     void decodeSectorRecord()
 	{
-		/* Skip ID (as we know it's a MAC_SECTOR_RECORD). */
-		readRawBits(24);
+		if (readRaw24() != MAC_SECTOR_RECORD)
+			return;
 
 		/* Read header. */
 
@@ -165,8 +165,7 @@ public:
 
     void decodeDataRecord()
 	{
-		auto id = toBytes(readRawBits(24)).reader().read_be24();
-		if (id != MAC_DATA_RECORD)
+		if (readRaw24() != MAC_DATA_RECORD)
 			return;
 
 		/* Read data. */

--- a/arch/micropolis/decoder.cc
+++ b/arch/micropolis/decoder.cc
@@ -33,15 +33,10 @@ public:
 		_config(config.micropolis())
 	{}
 
-	RecordType advanceToNextRecord()
+	nanoseconds_t advanceToNextRecord() override
 	{
-		_fmr->seekToIndexMark();
-		const FluxMatcher* matcher = nullptr;
-		_sector->clock = _fmr->seekToPattern(SECTOR_SYNC_PATTERN, matcher);
-		if (matcher == &SECTOR_SYNC_PATTERN) {
-			return SECTOR_RECORD;
-		}
-		return UNKNOWN_RECORD;
+		seekToIndexMark();
+		return seekToPattern(SECTOR_SYNC_PATTERN);
 	}
 
 	void decodeSectorRecord()

--- a/arch/mx/decoder.cc
+++ b/arch/mx/decoder.cc
@@ -16,8 +16,10 @@ const int SECTOR_SIZE = 256;
  */
 
 /* FM beginning of track marker:
+ *         0         0         f         3 decoded nibbles
+ *  0 0  0 0  0 0  0 0  1 1  1 1  0 0  1 1
  * 1010 1010 1010 1010 1111 1111 1010 1111
- *    a    a    a    a    f    f    a    f
+ *    a    a    a    a    f    f    a    f encoded nibbles
  */
 const FluxPattern ID_PATTERN(32, 0xaaaaffaf);
 
@@ -30,59 +32,43 @@ public:
 
     void beginTrack()
 	{
-		_currentSector = -1;
-		_clock = 0;
+		_clock = _sector->clock = seekToPattern(ID_PATTERN);
+		_currentSector = 0;
 	}
 
-    RecordType advanceToNextRecord()
+    nanoseconds_t advanceToNextRecord() override
 	{
-		if (_currentSector == -1)
-		{
-			/* First sector in the track: look for the sync marker. */
-			const FluxMatcher* matcher = nullptr;
-			_sector->clock = _clock = _fmr->seekToPattern(ID_PATTERN, matcher);
-			readRawBits(32); /* skip the ID mark */
-			_logicalTrack = decodeFmMfm(readRawBits(32)).slice(0, 32).reader().read_be16();
-		}
-		else if (_currentSector == 10)
+		if (_currentSector == 10)
 		{
 			/* That was the last sector on the disk. */
-			return UNKNOWN_RECORD;
+			return 0;
 		}
 		else
-		{
-			/* Otherwise we assume the clock from the first sector is still valid.
-			 * The decoder framwork will automatically stop when we hit the end of
-			 * the track. */
-			_sector->clock = _clock;
-		}
-
-		_currentSector++;
-		return SECTOR_RECORD;
+			return _clock;
 	}
 
     void decodeSectorRecord()
 	{
 		auto bits = readRawBits((SECTOR_SIZE+2)*16);
-		auto bytes = decodeFmMfm(bits).slice(0, SECTOR_SIZE+2).swab();
+		auto bytes = decodeFmMfm(bits).slice(0, SECTOR_SIZE+2);
 
 		uint16_t gotChecksum = 0;
 		ByteReader br(bytes);
 		for (int i=0; i<(SECTOR_SIZE/2); i++)
-			gotChecksum += br.read_le16();
-		uint16_t wantChecksum = br.read_le16();
+			gotChecksum += br.read_be16();
+		uint16_t wantChecksum = br.read_be16();
 
-		_sector->logicalTrack = _logicalTrack;
+		_sector->logicalTrack = _sector->physicalCylinder;
 		_sector->logicalSide = _sector->physicalHead;
 		_sector->logicalSector = _currentSector;
-		_sector->data = bytes.slice(0, SECTOR_SIZE);
+		_sector->data = bytes.slice(0, SECTOR_SIZE).swab();
 		_sector->status = (gotChecksum == wantChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;
+		_currentSector++;
 	}
 
 private:
     nanoseconds_t _clock;
     int _currentSector;
-    int _logicalTrack;
 };
 
 std::unique_ptr<AbstractDecoder> createMxDecoder(const DecoderProto& config)

--- a/arch/tids990/decoder.cc
+++ b/arch/tids990/decoder.cc
@@ -23,17 +23,19 @@
  * When shifted out of phase, the special 0xa1 byte becomes an illegal
  * encoding (you can't do 10 00). So this can't be spoofed by user data.
  */
+const uint16_t SECTOR_ID = 0x550a;
 const FluxPattern SECTOR_RECORD_PATTERN(32, 0x11112244);
 
 /*
  * Data record:
- * data:    0  1  0  1  0  1  0  1 .0  0  0  0  1  0  1  1  = 0x550c
+ * data:    0  1  0  1  0  1  0  1 .0  0  0  0  1  0  1  1  = 0x550b
  * mfm:     00 01 00 01 00 01 00 01.00 10 10 10 01 00 01 01 = 0x11112a45
  * special: 00 01 00 01 00 01 00 01.00 10 00 10 01 00 01 01 = 0x11112245
  *                                        ^^
  * When shifted out of phase, the special 0xa1 byte becomes an illegal
  * encoding (you can't do 10 00). So this can't be spoofed by user data.
  */
+const uint16_t DATA_ID = 0x550b;
 const FluxPattern DATA_RECORD_PATTERN(32, 0x11112245);
 
 const FluxMatchers ANY_RECORD_PATTERN({ &SECTOR_RECORD_PATTERN, &DATA_RECORD_PATTERN });
@@ -56,9 +58,11 @@ public:
 		auto bytes = decodeFmMfm(bits).slice(0, TIDS990_SECTOR_RECORD_SIZE);
 
 		ByteReader br(bytes);
+		if (br.read_be16() != SECTOR_ID)
+			return;
+
 		uint16_t gotChecksum = crc16(CCITT_POLY, bytes.slice(1, TIDS990_SECTOR_RECORD_SIZE-3));
 
-		br.seek(2);
 		_sector->logicalSide = br.read_8() >> 3;
 		_sector->logicalTrack = br.read_8();
 		br.read_8(); /* number of sectors per track */
@@ -76,9 +80,11 @@ public:
 		auto bytes = decodeFmMfm(bits).slice(0, TIDS990_DATA_RECORD_SIZE);
 
 		ByteReader br(bytes);
+		if (br.read_be16() != DATA_ID)
+			return;
+
 		uint16_t gotChecksum = crc16(CCITT_POLY, bytes.slice(1, TIDS990_DATA_RECORD_SIZE-3));
 
-		br.seek(2);
 		_sector->data = br.read(TIDS990_PAYLOAD_SIZE);
 		uint16_t wantChecksum = br.read_be16();
 		_sector->status = (wantChecksum == gotChecksum) ? Sector::OK : Sector::BAD_CHECKSUM;

--- a/arch/tids990/decoder.cc
+++ b/arch/tids990/decoder.cc
@@ -45,15 +45,9 @@ public:
 		AbstractDecoder(config)
 	{}
 
-    RecordType advanceToNextRecord()
+    nanoseconds_t advanceToNextRecord() override
 	{
-		const FluxMatcher* matcher = nullptr;
-		_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
-		if (matcher == &SECTOR_RECORD_PATTERN)
-			return RecordType::SECTOR_RECORD;
-		if (matcher == &DATA_RECORD_PATTERN)
-			return RecordType::DATA_RECORD;
-		return RecordType::UNKNOWN_RECORD;
+		return seekToPattern(ANY_RECORD_PATTERN);
 	}
 
     void decodeSectorRecord()

--- a/arch/victor9k/decoder.cc
+++ b/arch/victor9k/decoder.cc
@@ -59,15 +59,9 @@ public:
 		AbstractDecoder(config)
 	{}
 
-    RecordType advanceToNextRecord()
+    nanoseconds_t advanceToNextRecord() override
 	{
-		const FluxMatcher* matcher = nullptr;
-		_sector->clock = _fmr->seekToPattern(ANY_RECORD_PATTERN, matcher);
-		if (matcher == &SECTOR_RECORD_PATTERN)
-			return SECTOR_RECORD;
-		if (matcher == &DATA_RECORD_PATTERN)
-			return DATA_RECORD;
-		return UNKNOWN_RECORD;
+		return seekToPattern(ANY_RECORD_PATTERN);
 	}
 
     void decodeSectorRecord()

--- a/arch/zilogmcz/decoder.cc
+++ b/arch/zilogmcz/decoder.cc
@@ -20,14 +20,10 @@ public:
 		AbstractDecoder(config)
 	{}
 
-    RecordType advanceToNextRecord()
+    nanoseconds_t advanceToNextRecord() override
 	{
-		const FluxMatcher* matcher = nullptr;
-		_fmr->seekToIndexMark();
-		_sector->clock = _fmr->seekToPattern(SECTOR_START_PATTERN, matcher);
-		if (matcher == &SECTOR_START_PATTERN)
-			return SECTOR_RECORD;
-		return UNKNOWN_RECORD;
+		seekToIndexMark();
+		return seekToPattern(SECTOR_START_PATTERN);
 	}
 
     void decodeSectorRecord()

--- a/lib/bytes.cc
+++ b/lib/bytes.cc
@@ -279,6 +279,16 @@ ByteWriter Bytes::writer()
     return ByteWriter(*this);
 }
 
+uint64_t ByteReader::read_be48()
+{
+	return ((uint64_t)read_be16() << 32) | read_be32();
+}
+
+uint64_t ByteReader::read_be64()
+{
+	return ((uint64_t)read_be32() << 32) | read_be32();
+}
+
 ByteWriter& ByteWriter::operator +=(std::istream& stream)
 {
     Bytes buffer(4096);

--- a/lib/bytes.h
+++ b/lib/bytes.h
@@ -131,6 +131,9 @@ public:
         return (b1<<24) | (b2<<16) | (b3<<8) | b4;
     }
 
+    uint64_t read_be48();
+    uint64_t read_be64();
+
     uint16_t read_le16()
     {
         uint8_t b1 = _bytes[pos++];

--- a/lib/decoders/decoders.cc
+++ b/lib/decoders/decoders.cc
@@ -156,6 +156,46 @@ std::vector<bool> AbstractDecoder::readRawBits(unsigned count)
 	return _decoder->readBits(count);
 }
 
+uint8_t AbstractDecoder::readRaw8()
+{
+	return toBytes(readRawBits(8)).reader().read_8();
+}
+
+uint16_t AbstractDecoder::readRaw16()
+{
+	return toBytes(readRawBits(16)).reader().read_be16();
+}
+
+uint32_t AbstractDecoder::readRaw20()
+{
+	std::vector<bool> bits(4);
+	for (bool b : readRawBits(20))
+		bits.push_back(b);
+
+	return toBytes(bits).reader().read_be24();
+}
+
+uint32_t AbstractDecoder::readRaw24()
+{
+	return toBytes(readRawBits(24)).reader().read_be24();
+}
+
+uint32_t AbstractDecoder::readRaw32()
+{
+	return toBytes(readRawBits(32)).reader().read_be32();
+}
+
+uint64_t AbstractDecoder::readRaw48()
+{
+	return toBytes(readRawBits(48)).reader().read_be48();
+}
+
+uint64_t AbstractDecoder::readRaw64()
+{
+	return toBytes(readRawBits(64)).reader().read_be64();
+}
+
+
 std::set<unsigned> AbstractDecoder::requiredSectors(unsigned cylinder, unsigned head) const
 {
 	static std::set<unsigned> set;

--- a/lib/decoders/decoders.h
+++ b/lib/decoders/decoders.h
@@ -85,6 +85,7 @@ protected:
 	std::unique_ptr<TrackDataFlux> _trackdata;
     std::shared_ptr<Sector> _sector;
 	std::unique_ptr<FluxDecoder> _decoder;
+	std::vector<bool> _recordBits;
 
 private:
     FluxmapReader* _fmr = nullptr;

--- a/lib/decoders/decoders.h
+++ b/lib/decoders/decoders.h
@@ -50,6 +50,13 @@ public:
 
 	void resetFluxDecoder();
     std::vector<bool> readRawBits(unsigned count);
+	uint8_t readRaw8();
+	uint16_t readRaw16();
+	uint32_t readRaw20();
+	uint32_t readRaw24();
+	uint32_t readRaw32();
+	uint64_t readRaw48();
+	uint64_t readRaw64();
 
     Fluxmap::Position tell()
     { return _fmr->tell(); } 

--- a/lib/decoders/decoders.h
+++ b/lib/decoders/decoders.h
@@ -57,22 +57,30 @@ public:
     void seek(const Fluxmap::Position& pos)
     { return _fmr->seek(pos); } 
 
+	nanoseconds_t seekToPattern(const FluxMatcher& pattern);
+	void seekToIndexMark();
+
     bool eof() const
     { return _fmr->eof(); }
+
+	nanoseconds_t getFluxmapDuration() const
+	{ return _fmr->getDuration(); }
 
 	virtual std::set<unsigned> requiredSectors(unsigned cylinder, unsigned head) const;
 
 protected:
     virtual void beginTrack() {};
-    virtual RecordType advanceToNextRecord() = 0;
+    virtual nanoseconds_t advanceToNextRecord() = 0;
     virtual void decodeSectorRecord() = 0;
     virtual void decodeDataRecord() {};
 
 	const DecoderProto& _config;
-    FluxmapReader* _fmr = nullptr;
 	std::unique_ptr<TrackDataFlux> _trackdata;
     std::shared_ptr<Sector> _sector;
 	std::unique_ptr<FluxDecoder> _decoder;
+
+private:
+    FluxmapReader* _fmr = nullptr;
 };
 
 #endif

--- a/scripts/encodedecodetest.sh
+++ b/scripts/encodedecodetest.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-tmp=/tmp/$$
+format=$1
+tmp=/tmp/$$-$format
 srcfile=$tmp.src.img
 fluxfile=$tmp.$2
 destfile=$tmp.dest.img
-format=$1
 shift
 shift
 


### PR DESCRIPTION
This reworks all the decoders to avoid seeking inside the fluxmap when doing reads. This requires resetting the FluxDecoder, which loses any pending state, resulting in bad reads for (some) formats which don't have gaps between sectors --- the DVK MX is the main victim.

Closes: #438