### PR TITLE
Some quality of life improvements for Adafruit generic GW-compatibles

### DIFF
--- a/lib/usb/serial.cc
+++ b/lib/usb/serial.cc
@@ -156,6 +156,9 @@
 			usleep(200000);
 			if (ioctl(_fd, TIOCMBIS, &flag) == -1)
 				Error() << fmt::format("cannot set DTR on serial port: {}", strerror(errno));
+
+			/* Flush pending input from a generic greaseweazel device */
+			tcsetattr(_fd, TCSAFLUSH, &t);
 		}
 
 		~SerialPortImpl() override
@@ -167,6 +170,8 @@
 		ssize_t readImpl(uint8_t* buffer, size_t len) override
 		{
 			ssize_t rlen = ::read(_fd, buffer, len);
+			if (rlen == 0)
+				Error() << "serial read returned no data (device removed?)";
 			if (rlen == -1)
 				Error() << fmt::format("serial read I/O error: {}", strerror(errno));
 			return rlen;


### PR DESCRIPTION
The addition of the new `tcsetattr` call fixes a problem where interrupting fluxengine during a flux read will leave data in the device and/or Linux's serial buffers, so that the next invocation of fluxengine will fail similar to
```
Error: command returned garbage (0x27 != 0x0 with status 0x31)
```
(the specific value differs because it's actually flux data)

Merely changing the existing `tcsetattr` call to specify `TCSAFLUSH` was not enough; moving it after the 200ms pause seems to be enough.

Note that it doesn't seem feasible in our USB stack to make DTR reset the device, since that would take down the USB stack and require a fresh USB connection.

The addition of the special case for `rlen == 0` in read is for when the GW-compatible board is reset or crashes and usb-disconnects during a reading operation. Without this change, fluxengine spins forever at 100% of a CPU, repeating a read().  After the change, this will cause the host computer to print messages like:
```
  2.1: 200 ms in 68928 bytes
  3.0: Error: serial read returned no data (device removed?)
```
and exit.

I only tested these changes on Linux (Debian with kernel 5.10) and in particular I don't know if/how it will work on a Mac.