### PR TITLE
Fix the Atari ST profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ people who've had it work).
 | Format                                    | Read? | Write? | Notes |
 |:------------------------------------------|:-----:|:------:|-------|
 | [IBM PC compatible](doc/disk-ibm.md)      |  🦄   |   🦄   | and compatibles (like the Atari ST) |
+| [Atari ST](doc/disk-atarist.md)           |  🦄   |   🦄   | technically the same as IBM, almost |
 | [Acorn ADFS](doc/disk-acornadfs.md)       |  🦄   |   🦖*  | single- and double- sided           |
 | [Acorn DFS](doc/disk-acorndfs.md)         |  🦄   |   🦖*  |                                     |
 | [Ampro Little Board](doc/disk-ampro.md)   |  🦖   |   🦖*  |                                     |
@@ -102,7 +103,7 @@ people who've had it work).
 | [Brother 120kB](doc/disk-brother.md)      |  🦄   |   🦖   |                                     |
 | [Brother 240kB](doc/disk-brother.md)      |  🦄   |   🦄   |                                     |
 | [Brother FB-100](doc/disk-fb100.md)       |  🦖   |        | Tandy Model 100, Husky Hunter, knitting machines |
-| [Macintosh 800kB](doc/disk-macintosh.md)  |  🦄   |   🦄   | and probably the 400kB too          |
+| [Macintosh 400kB/800kB](doc/disk-macintosh.md)  |  🦄   |   🦄   |                                     |
 | [NEC PC-98](doc/disk-ibm.md)              |  🦄   |   🦄   | trimode drive not required          |
 | [Sharp X68000](doc/disk-ibm.md)           |  🦄   |   🦄   |                                     |
 | [TRS-80](doc/disk-trs80.md)               |  🦖   |   🦖*  | a minor variation of the IBM scheme |

--- a/arch/ibm/decoder.cc
+++ b/arch/ibm/decoder.cc
@@ -156,6 +156,13 @@ public:
 			_sector->logicalSide = _sector->physicalHead;
 		if (trackdata.ignore_track_byte())
 			_sector->logicalTrack = _sector->physicalCylinder;
+
+		for (int sector : trackdata.ignore_sector())
+			if (_sector->logicalSector == sector)
+			{
+				_sector->status = Sector::MISSING;
+				break;
+			}
 	}
 
     void decodeDataRecord() override

--- a/arch/ibm/ibm.proto
+++ b/arch/ibm/ibm.proto
@@ -3,7 +3,7 @@ syntax = "proto2";
 import "lib/common.proto";
 
 message IbmDecoderProto {
-	// Next: 10
+	// Next: 11
 	message TrackdataProto {
 		message SectorsProto {
 			repeated int32 sector = 1            [(help) = "require these sectors to exist for a good read"];
@@ -19,6 +19,8 @@ message IbmDecoderProto {
 		optional bool ignore_side_byte = 2       [default = false, (help) = "ignore side byte in sector header"];
 		optional bool ignore_track_byte = 6      [default = false, (help) = "ignore track byte in sector header"];
 		optional bool swap_sides = 4             [default = false, (help) = "put logical side 1 on physical side 0"];
+
+		repeated int32 ignore_sector = 10        [(help) = "sectors with these IDs will not be read"];
 
 		oneof required_sectors {
 			SectorsProto sectors = 5             [(help) = "require these sectors to exist for a good read"];

--- a/doc/disk-atarist.md
+++ b/doc/disk-atarist.md
@@ -5,6 +5,10 @@ Atari ST disks are standard MFM encoded IBM scheme disks without an IAM header.
 Disks are typically formatted 512 bytes per sector with between 9-10 (sometimes
 11!) sectors per track and 80-82 tracks per side.
 
+For some reason, occasionally formatting software will put an extra IDAM record
+with a sector number of 66 on a disk, which can horribly confuse things. The
+Atari profiles below are configured to ignore these.
+
 
 Reading disks
 -------------

--- a/doc/disk-atarist.md
+++ b/doc/disk-atarist.md
@@ -9,6 +9,7 @@ For some reason, occasionally formatting software will put an extra IDAM record
 with a sector number of 66 on a disk, which can horribly confuse things. The
 Atari profiles below are configured to ignore these.
 
+Be aware that many PC drives (including mine) won't do the 82 track formats. 
 
 Reading disks
 -------------

--- a/src/formats/atarist360.textpb
+++ b/src/formats/atarist360.textpb
@@ -58,6 +58,7 @@ encoder {
 decoder {
 	ibm {
 		trackdata {
+			ignore_sector: 66
 			sector_range {
 				min_sector: 1
 				max_sector: 9

--- a/src/formats/atarist370.textpb
+++ b/src/formats/atarist370.textpb
@@ -57,6 +57,7 @@ encoder {
 decoder {
 	ibm {
 		trackdata {
+			ignore_sector: 66
 			sector_range {
 				min_sector: 1
 				max_sector: 9

--- a/src/formats/atarist400.textpb
+++ b/src/formats/atarist400.textpb
@@ -58,6 +58,7 @@ encoder {
 decoder {
 	ibm {
 		trackdata {
+			ignore_sector: 66
 			sector_range {
 				min_sector: 1
 				max_sector: 10

--- a/src/formats/atarist410.textpb
+++ b/src/formats/atarist410.textpb
@@ -58,6 +58,7 @@ encoder {
 decoder {
 	ibm {
 		trackdata {
+			ignore_sector: 66
 			sector_range {
 				min_sector: 1
 				max_sector: 10

--- a/src/formats/atarist720.textpb
+++ b/src/formats/atarist720.textpb
@@ -57,6 +57,7 @@ encoder {
 decoder {
 	ibm {
 		trackdata {
+			ignore_sector: 66
 			sector_range {
 				min_sector: 1
 				max_sector: 9

--- a/src/formats/atarist740.textpb
+++ b/src/formats/atarist740.textpb
@@ -57,6 +57,7 @@ encoder {
 decoder {
 	ibm {
 		trackdata {
+			ignore_sector: 66
 			sector_range {
 				min_sector: 1
 				max_sector: 9

--- a/src/formats/atarist800.textpb
+++ b/src/formats/atarist800.textpb
@@ -58,6 +58,7 @@ encoder {
 decoder {
 	ibm {
 		trackdata {
+			ignore_sector: 66
 			sector_range {
 				min_sector: 1
 				max_sector: 10

--- a/src/formats/atarist820.textpb
+++ b/src/formats/atarist820.textpb
@@ -58,6 +58,7 @@ encoder {
 decoder {
 	ibm {
 		trackdata {
+			ignore_sector: 66
 			sector_range {
 				min_sector: 1
 				max_sector: 10


### PR DESCRIPTION
It turns out that some ST formatter programs add an extra IDAM record with sector number 66 to the disk, which needs filtering out.