### PR TITLE
upgrade-flux-file: Fix for Windows

### DIFF
--- a/tools/upgrade-flux-file.cc
+++ b/tools/upgrade-flux-file.cc
@@ -300,6 +300,12 @@ int main(int argc, const char* argv[])
         std::cout << "Writing output file...\n";
     }
 
+    sqlite3_close(db);
+
+    if (remove(filename.c_str()) != 0)
+        Error() << fmt::format(
+            "couldn't remove input file: {}", strerror(errno));
+
     if (rename(outFilename.c_str(), filename.c_str()) != 0)
         Error() << fmt::format(
             "couldn't replace input file: {}", strerror(errno));


### PR DESCRIPTION
The upgrade-flux-file utility does not work properly under Windows.  It runs into an error because the open database file cannot be renamed in-place.

Close the database and remove the input file prior to renaming.

Tested this change on Windows, MacOS, Linux.