### PR TITLE
Add support for PDP-11 RX-50 disks

### DIFF
--- a/doc/disk-ibm.md
+++ b/doc/disk-ibm.md
@@ -18,6 +18,7 @@ metadata. Systems which use IBM scheme disks include but are not limited to:
   - NEC PC-98 series
   - Sharp X68000
   - Fujitsu FM Towns
+  - VAX & PDP-11
   - etc
 
 FluxEngine supports reading these. However, some variants are more peculiar

--- a/mkninja.sh
+++ b/mkninja.sh
@@ -530,6 +530,7 @@ FORMATS="\
     northstar87 \
     tids990 \
     vgi \
+    rx50 \
     victor9k_ss \
     victor9k_ds \
     zilogmcz \

--- a/mkninja.sh
+++ b/mkninja.sh
@@ -528,9 +528,9 @@ FORMATS="\
     northstar175 \
     northstar350 \
     northstar87 \
+    rx50 \
     tids990 \
     vgi \
-    rx50 \
     victor9k_ss \
     victor9k_ds \
     zilogmcz \

--- a/mkninja.sh
+++ b/mkninja.sh
@@ -650,6 +650,7 @@ encodedecodetest ibm720_525
 encodedecodetest mac400 scripts/mac400_test.textpb
 encodedecodetest mac800 scripts/mac800_test.textpb
 encodedecodetest n88basic
+encodedecodetest rx50
 encodedecodetest tids990
 encodedecodetest victor9k_ss
 encodedecodetest victor9k_ds

--- a/src/formats/rx50.textpb
+++ b/src/formats/rx50.textpb
@@ -1,4 +1,4 @@
-comment: 'Digital RX50 400kB 5.25" 80-track 10-sector SSHD'
+comment: 'Digital RX50 400kB 5.25" 80-track 10-sector SSQD'
 
 flux_sink {
 	drive {

--- a/src/formats/rx50.textpb
+++ b/src/formats/rx50.textpb
@@ -1,0 +1,76 @@
+comment: 'RX50 450kB 5.25" 80-track 10-sector SSHD'
+
+flux_sink {
+	drive {
+		high_density: true
+	}
+}
+
+flux_source {
+	drive {
+		high_density: true
+	}
+}
+
+image_reader {
+	filename: "ibm1200_525.img"
+	img {
+		tracks: 80
+		sides: 2
+		trackdata {
+			sector_size: 512
+			sector_range {
+				start_sector: 1
+				sector_count: 10
+			}
+		}
+	}
+}
+
+image_writer {
+	filename: "ibm1200_525.img"
+	img {}
+}
+
+encoder {
+	ibm {
+		trackdata {
+			track_length_ms: 167
+			clock_rate_khz: 500
+			sectors {
+				sector: 1
+				sector: 2
+				sector: 3
+				sector: 4
+				sector: 5
+				sector: 6
+				sector: 7
+				sector: 8
+				sector: 9
+				sector: 10
+			}
+		}
+	}
+}
+
+decoder {
+	ibm {
+		trackdata {
+			sector_range {
+				min_sector: 1
+				max_sector: 10
+			}
+		}
+	}
+}
+
+cylinders {
+	start: 0
+	end: 79
+}
+
+heads {
+	start: 0
+	end: 0
+}
+

--- a/src/formats/rx50.textpb
+++ b/src/formats/rx50.textpb
@@ -1,4 +1,4 @@
-comment: 'RX50 450kB 5.25" 80-track 10-sector SSHD'
+comment: 'Digital RX50 400kB 5.25" 80-track 10-sector SSHD'
 
 flux_sink {
 	drive {
@@ -13,7 +13,7 @@ flux_source {
 }
 
 image_reader {
-	filename: "ibm1200_525.img"
+	filename: "rx50.img"
 	img {
 		tracks: 80
 		sides: 2
@@ -28,7 +28,7 @@ image_reader {
 }
 
 image_writer {
-	filename: "ibm1200_525.img"
+	filename: "rx50.img"
 	img {}
 }
 

--- a/src/formats/rx50.textpb
+++ b/src/formats/rx50.textpb
@@ -16,7 +16,7 @@ image_reader {
 	filename: "rx50.img"
 	img {
 		tracks: 80
-		sides: 2
+		sides: 1
 		trackdata {
 			sector_size: 512
 			sector_range {
@@ -36,7 +36,8 @@ encoder {
 	ibm {
 		trackdata {
 			track_length_ms: 167
-			clock_rate_khz: 500
+			clock_rate_khz: 300
+			gap3: 30
 			sectors {
 				sector: 1
 				sector: 2


### PR DESCRIPTION
According to my source [https://www.cbmstuff.com/forum/showthread.php?tid=634] the format of RX-50 is

 * single sided
 * 80 tracks
 * 10 sectors per track
 * 96 tpi (tracks per inch)
 * 300 rpm (revolutions per minute)
 * 250 KHz data rate

I have a disk labeled
```
BL-T540E-MC
CZUFDE0 MICRO PDP-11
USER TESTS
© 1983, 1894
DIGITAL EQUIPMENT CORP.
```
and stamped 14131.

The image read all sectors and the content looks plausible.  `strings` on it says things like
```
$ strings rx50.img  | grep -i pdp
; This file implements the USER FRIENDLY Diagnostic for the MICRO PDP11 & 11/73
```
however, I don't have an emulator or other system to use the disk image with so
I can't 100% vouch for the image being complete and correct.