### PR TITLE
fluxmap: Don't push_back() if Fluxmap begins with F_DESYNC.

### DIFF
--- a/lib/fluxmap.cc
+++ b/lib/fluxmap.cc
@@ -99,7 +99,8 @@ std::vector<Fluxmap> Fluxmap::split() {
     Fluxmap map;
     for (unsigned i=0; i<_bytes.size(); i++) {
         if (_bytes[i] == F_DESYNC) {
-            maps.push_back(map);
+            if (i > 0)
+                maps.push_back(map);
             map = Fluxmap();
         } else {
             map.appendByte(_bytes[i]);


### PR DESCRIPTION
Fluxmap::split() creates a 0-length Fluxmap if the Fluxmap
begins with F_DESYNC.  Fix this by not doing push_back()
if a F_DESYNC is encountered at the start of the Fluxmap.