### PR TITLE
Improve hard sector decode

### DIFF
--- a/arch/micropolis/decoder.cc
+++ b/arch/micropolis/decoder.cc
@@ -103,6 +103,15 @@ public:
 			clock = seekToPattern(SECTOR_SYNC_PATTERN);
 		}
 
+		_sector->headerStartTime = tell().ns();
+
+		/* seekToPattern() can skip past the index hole, if this happens
+		 * too close to the end of the Fluxmap, discard the sector.
+		 */
+		if (_sector->headerStartTime > (getFluxmapDuration() - 12.5e6)) {
+			return 0;
+		}
+
 		return clock;
 	}
 

--- a/arch/northstar/decoder.cc
+++ b/arch/northstar/decoder.cc
@@ -106,8 +106,14 @@ public:
 		 * _hardSectorId after the sector header is found.
 		 */
 		nanoseconds_t clock = seekToPattern(ANY_SECTOR_PATTERN);
+		_sector->headerStartTime = tell().ns();
 
-		int sectorFoundTimeRaw = std::round((tell().ns()) / 1e6);
+		/* Discard a possible partial sector. */
+		if (_sector->headerStartTime > (getFluxmapDuration() - 21e6)) {
+			return 0;
+		}
+
+		int sectorFoundTimeRaw = std::round(_sector->headerStartTime / 1e6);
 		int sectorFoundTime;
 
 		/* Round time to the nearest 20ms */


### PR DESCRIPTION
seekToPattern() can skip the index hole if it doesn't find the
SYNC pattern.  If this happens too close to the end of the flux
stream, it can result in a conflicted sector.  In this case,
discard the sector.

This makes a small improvement for #328 on some disks.