### PR TITLE
works in physical victor 9000 machine

### DIFF
--- a/arch/victor9k/encoder.cc
+++ b/arch/victor9k/encoder.cc
@@ -87,6 +87,18 @@ static void write_bytes(std::vector<bool>& bits, unsigned& cursor, const Bytes& 
     }
 }
 
+static void write_gap(std::vector<bool>& bits, unsigned& cursor, int length)
+{
+	std::string zero("0");
+	std::string gap(""); 
+	for (int i = 0; i < length/10; i++)
+	{
+		gap += zero;
+	}	
+	Bytes byte_gap(gap);
+	write_bytes(bits, cursor, byte_gap);
+}
+
 static void write_sector(std::vector<bool>& bits, unsigned& cursor,
 		const Victor9kEncoderProto::TrackdataProto& trackdata,
         const Sector& sector)
@@ -102,8 +114,8 @@ static void write_sector(std::vector<bool>& bits, unsigned& cursor,
         (uint8_t)(encodedTrack + encodedSector),
     });
 
+    write_gap(bits, cursor, trackdata.post_header_gap_bits());
 
-    write_zero_bits(bits, cursor, trackdata.post_header_gap_bits());
     write_one_bits(bits, cursor, trackdata.pre_data_sync_bits());
     write_bits(bits, cursor, VICTOR9K_DATA_RECORD, 10);
 
@@ -113,7 +125,9 @@ static void write_sector(std::vector<bool>& bits, unsigned& cursor,
     checksum.writer().write_le16(sumBytes(sector.data));
     write_bytes(bits, cursor, checksum);
 
-    write_zero_bits(bits, cursor, trackdata.post_data_gap_bits());
+    // Bytes post_data_gap_bytes("000000000000000000000000000000");
+    // write_bytes(bits, cursor, post_data_gap_bytes);
+    write_gap(bits, cursor, trackdata.post_data_gap_bits());
 }
 
 class Victor9kEncoder : public AbstractEncoder

--- a/arch/victor9k/victor9k.h
+++ b/arch/victor9k/victor9k.h
@@ -8,11 +8,13 @@ class DecoderProto;
 
 /* ... 1101 0101 0111
  *       ^^ ^^^^ ^^^^ ten bit IO byte */
-#define VICTOR9K_SECTOR_RECORD 0xfffffd57 
+#define VICTOR9K_SECTOR_RECORD 0xfffffd57
+#define VICTOR9K_HEADER_ID 0x7
 
 /* ... 1101 0100 1001
  *       ^^ ^^^^ ^^^^ ten bit IO byte */
 #define VICTOR9K_DATA_RECORD   0xfffffd49
+#define VICTOR9K_DATA_ID 0x8
 
 #define VICTOR9K_SECTOR_LENGTH 512
 

--- a/src/formats/victor9k_ds.textpb
+++ b/src/formats/victor9k_ds.textpb
@@ -287,12 +287,12 @@ image_writer {
 encoder {
 	victor9k {
 		trackdata {
-			original_data_rate_khz: 500
-			post_index_gap_us: 1000.0
-			pre_header_sync_bits: 120
-			post_header_gap_bits: 48
+			original_data_rate_khz: 468
+			post_index_gap_us: 500.0
+			pre_header_sync_bits: 150
+			post_header_gap_bits: 60
 			pre_data_sync_bits: 40
-			post_data_gap_bits: 200
+			post_data_gap_bits: 300
 		}
 		trackdata {
 			head: 0

--- a/src/formats/victor9k_ss.textpb
+++ b/src/formats/victor9k_ss.textpb
@@ -143,11 +143,11 @@ image_writer {
 encoder {
 	victor9k {
 		trackdata {
-			original_data_rate_khz: 500
-			post_index_gap_us: 1000.0
-			pre_header_sync_bits: 60
-			post_header_gap_bits: 90
-			pre_data_sync_bits: 50
+			original_data_rate_khz: 468
+			post_index_gap_us: 500.0
+			pre_header_sync_bits: 150
+			post_header_gap_bits: 60
+			pre_data_sync_bits: 40
 			post_data_gap_bits: 300
 		}
 		trackdata {


### PR DESCRIPTION
Hi David,
I've tested this with both SS and DS disks on two different physical machines and it works reliably. I can also image these disks with an Applesauce, so I think we have a winner. I'm not a C++ guy, so apologies if the write_gap() isn't idiomatic. I'm just trying to write I/O encoded zeros. I tried using your suggestion of fillBitmapTo() and that didn't work, but this solution does. 

Thanks much for your help with all this. I've tested writing about 5 different disks at this point, so I'm feeling relatively good.

Paul