### PR TITLE
apple2: Comment decoder, add fix/workaround for stray 0 at start of sector data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,10 @@ ifneq ($(packages-exist),yes)
 $(warning These pkg-config packages are installed: $(shell pkg-config --list-all | sort | awk '{print $$1}'))
 $(error You must have these pkg-config packages installed: $(PACKAGES))
 endif
+wx-exist = $(shell wx-config --cflags > /dev/null && echo yes)
+ifneq ($(wx-exist),yes)
+$(error You must have these wx-config installed)
+endif
 
 export PROTOC = protoc
 export CC = gcc

--- a/arch/apple2/decoder.cc
+++ b/arch/apple2/decoder.cc
@@ -104,6 +104,20 @@ public:
 		if (readRaw24() != APPLE2_DATA_RECORD)
 			return;
 
+		// Sometimes there's a 1-bit gap between APPLE2_DATA_RECORD and
+		// the data itself.  This has been seen on real world disks
+		// such as the Apple II Operating System Kit from Apple2Online.
+		// However, I haven't seen it described in any of the various
+		// references.
+		//
+		// This extra '0' bit would not affect the real disk interface,
+		// as it was a '1' reaching the top bit of a shift register
+		// that triggered a byte to be available, but it affects the
+		// way the data is read here.
+		auto p = tell();
+		auto b = readRawBits(1);
+		if(b[0]) seek(p);
+
 		/* Read and decode data. */
 
 		unsigned recordLength = APPLE2_ENCODED_SECTOR_LENGTH + 2;

--- a/arch/apple2/decoder.cc
+++ b/arch/apple2/decoder.cc
@@ -90,6 +90,9 @@ public:
 		_sector->logicalTrack = combine(br.read_be16());
 		_sector->logicalSector = combine(br.read_be16());
 		uint8_t checksum = combine(br.read_be16());
+
+		// If the checksum is correct, upgrade the sector from MISSING
+		// to DATA_MISSING in anticipation of its data record
 		if (checksum == (volume ^ _sector->logicalTrack ^ _sector->logicalSector))
 			_sector->status = Sector::DATA_MISSING; /* unintuitive but correct */
 	}
@@ -106,6 +109,9 @@ public:
 		unsigned recordLength = APPLE2_ENCODED_SECTOR_LENGTH + 2;
 		Bytes bytes = toBytes(readRawBits(recordLength*8)).slice(0, recordLength);
 
+		// Upgrade the sector from MISSING to BAD_CHECKSUM.
+		// If decode_crazy_data succeeds, it upgrades the sector to
+		// OK.
 		_sector->status = Sector::BAD_CHECKSUM;
 		_sector->data = decode_crazy_data(&bytes[0], _sector->status);
 	}


### PR DESCRIPTION
Sometimes there's a 1-bit gap between APPLE2_DATA_RECORD and the data itself.  This has been seen on real world disks such as the Apple II Operating System Kit from Apple2Online.  However, I haven't seen it described in any of the various references.                    
                  
This extra '0' bit would not affect the real disk interface, as it was a '1' reaching the top bit of a shift register that triggered a byte to be available, but it affects the way the data is read here.                                  

With this change, and a separate program to manipulate an image between physical order and logical DOS3.3 order, I was able to verify that the "Apple II Operating System Kit Apple DOS 3.3" disk that I imaged with FluxEngine is 1 bit different from the image available at https://apple2online.com/?page_id=4262 `Apple-DOS-All-Versions-1/Apple DOS 3.3 August 1980.dsk`. The difference is in a byte in the VTOC (filesystem metadata) that is marked as unused in the references I have. I don't know why this difference exists.

However, it feels like reading apple2 images is still pretty marginal, it took 9 separate read attempts (not the retry process within fluxengine, which was set at the default of 5 during this process) before I got an error-free disk image. A floppy freshly `INIT`ialized from DOS 3.3 is no better, and may be worse. I'll continue investigating on my end, because I don't know if this is the end of the story.

I also added some comments about how the sector validity flag is handled through the read process; I hope it's an improvement over simply announcing that the code is `/* unintuitive but correct */`.
