### PR TITLE
Further apple fixes - have now booted a DOS 3.3 written with FE + GW

### DIFF
--- a/arch/apple2/decoder.cc
+++ b/arch/apple2/decoder.cc
@@ -123,15 +123,16 @@ public:
 		/* Read and decode data. */
 
 		auto readApple8 = [&]() {
-		    auto result = readRaw8();
-		    while(result & 0x80 == 0) {
+		    auto result = 0;
+		    while((result & 0x80) == 0) {
 			auto b = readRawBits(1);
+                        if(b.empty()) break;
 			result = (result << 1) | b[0];
 		    }
 		    return result;
 		};
 
-		constexpr unsigned recordLength = APPLE2_ENCODED_SECTOR_LENGTH + 2;
+		constexpr unsigned recordLength = APPLE2_ENCODED_SECTOR_LENGTH+2;
                 uint8_t bytes[recordLength];
                 for(auto &byte : bytes) {
                     byte = readApple8();


### PR DESCRIPTION
With this change, I was able to boot a DOS 3.3 disk I rearranged into "physical" order; some 'there's a disk error' raspberries occur (probably indicating a data error within a sector) during the boot process, so something is still obviously marginal, but this is a huge step forward.

It also fixes a crash that would occur reading an apple2 disk that was not aligned to the index sensor; during my testing, I was using an image I had written myself, so of course it was aligned. (At least, I think this is why I even believed it worked at all)