### PR TITLE
Add support for the interfacing to an Apple Disk ][

### DIFF
--- a/doc/greaseweazle.md
+++ b/doc/greaseweazle.md
@@ -37,8 +37,12 @@ Supported features with the GreaseWeazle include:
   - simple reading and writing of disks, seeking etc
   - erasing disks
   - determining disk rotation speed
-  - both Shugart and normal IBM buses (via
+  - Shugart and normal IBM buses (via
 	`--usb.greaseweazle.bus_type=SHUGART` or `IBMPC`; the default is `IBMPC`)
+  - Apple 5.25 floppy interfaces (via `--usb.greaseweazle.bus_type=APPLE2`)
+
+Which device types are supported depend on the hardware. Genuine Greaseweazle hardware supports SHUGART and IBMPC.
+APPLE2 is only supported with hand wiring and the Adafruit\_Floppy greaseweazle-compatible firmware.
 
 What doesn't work
 -----------------

--- a/lib/usb/greaseweazle.h
+++ b/lib/usb/greaseweazle.h
@@ -75,9 +75,10 @@ extern Bytes stripPartialRotation(const Bytes& fldata);
 /*
  * CMD_SET_BUS CODES
  */
-#define BUS_NONE            0
-#define BUS_IBMPC           1
-#define BUS_SHUGART         2
+#define BUS_NONE              0
+#define BUS_IBMPC             1
+#define BUS_SHUGART           2
+#define BUS_APPLE2            3
 
 
 /*

--- a/lib/usb/usb.proto
+++ b/lib/usb/usb.proto
@@ -3,7 +3,7 @@ syntax = "proto2";
 import "lib/common.proto";
 
 message GreaseWeazleProto {
-	enum BusType {
+	enum BusType { /* note that these must match CMD_SET_BUS codes */
 		BUSTYPE_INVALID = 0;
 		IBMPC = 1;
 		SHUGART = 2;


### PR DESCRIPTION
Some folks may want to use interfaces besides PC/Shugart ones. Together with https://github.com/adafruit/Adafruit_Floppy/pull/15 and a hand wired board I'm able to read flux from an Apple Disk ][ (don't sweat the bad sectors, this floppy was written before I mostly got the bugs out of flux generating for apple2s)

I've also started a dialog with @kierf about allocating these disk-type numbers. However, we haven't settled the details yet. This actual working code may be useful in figuring out the way forward among all of us:
 * https://github.com/keirf/greaseweazle/pull/171

Writing will have an additional wrinkle: The Apple2 stepping mechanism is designed so that it's possible to reach 3 intermediate positions between each of the ~35 data tracks. Because we hope to image protected floppies, which in some cases are said to  se these "quarter tracks", we want to expose the ability to reach all ~140 positions. This is APPLE2_QUARTERSTEP. However, right now the code to transform from a disk image's "cylinder number" to a floppy mechanism's "cylinder number" is a bit spread across the source. This may mean that it's just easiest to use APPLE2 (which presents 1 intermediate position between data tracks, just like when you stick an Apple disk in a PC drive) when writing.

In any case, I didn't wire the write and write-protect lines yet so writing isn't tested at all. The electrical interface is expected to be just fine.

```
$ ./fluxengine read apple2 --usb.greaseweazle.bus_type=APPLE2_QUARTERSTEP --usb.greaseweazle.port=/dev/ttyACM1 --flux_source.drive.high_density=0 -c 0-140x4 --decoder.retries=1
      38 raw records, 19 raw sectors; 4.04us clock (247kHz)
      sectors: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
      logical track 35.0
      4096 bytes decoded
     Tracks -> 1         2         3
H.SS 012345678901234567890123456789012345
0. 0 ....................................
0. 1 ....................................
0. 2 .BC...........CC...............C....
0. 3 ....................................
0. 4 ....................................
0. 5 ....................................
0. 6 B..B................................
0. 7 B...................................
0. 8 ....................................
0. 9 ....................................
0.10 B...................................
0.11 ....................................
0.12 ....................................
0.13 ....................................
0.14 ....................................
0.15 ....................................
Good sectors: 567/576 (98%)
Missing sectors: 0/576 (0%)
Bad sectors: 9/576 (1%)
      IMG: wrote 36 tracks, 1 sides, 144 kB total
```

```
$ ./fluxengine inspect --usb.greaseweazle.bus_type=APPLE2 --usb.greaseweazle.port=/dev/ttyACM1 --flux_source.drive.high_density=0
      Using GreaseWeazle on serial port /dev/ttyACM1
Measuring rotational speed... 202.3ms (296.6rpm)
0x12328 bytes of data in 242.003ms
Required USB bandwidth: 300.777210636634kB/s

Clock detection histogram:
 47 3.92    157 █
 48 4.00   1773 ███████████▋
 49 4.08   3273 █████████████████████▌
 50 4.17   2171 ██████████████▎
 51 4.25   2727 █████████████████▉
 52 4.33   3423 ██████████████████████▌
 53 4.42   1072 ███████
 54 4.50     93 ▌
...
 68 5.67    284 █▊
 69 5.75   2503 ████████████████▍
 70 5.83   4926 ████████████████████████████████▍
 71 5.92   5812 ██████████████████████████████████████▏
 72 6.00   6082 ████████████████████████████████████████
 73 6.08   3950 █████████████████████████▉
 74 6.17   3539 ███████████████████████▎
 75 6.25   1959 ████████████▉
 76 6.33    253 █▋
...
 94 7.83     61 ▍
 95 7.92    107 ▋
 96 8.00     76 ▍
 97 8.08     45 ▎
 98 8.17     55 ▎
 99 8.25     34 ▏
...
Noise floor:  60
Signal level: 304
Peak start:   46 (3.83 us)
Peak end:     55 (4.58 us)
Median:       50 (4.17 us)
4.17 us clock detected.
```