### PR TITLE
Greaseweazle: Fix RPM measurement in some circumstances.

### DIFF
--- a/lib/usb/greaseweazleusb.cc
+++ b/lib/usb/greaseweazleusb.cc
@@ -160,7 +160,7 @@ public:
                     }
 
                     case FLUXOP_SPACE:
-                        _serial->readBytes(4);
+                        ticks_gw += read_28();
                         break;
 
                     default:


### PR DESCRIPTION
Accumulate number of ticks returned in FLUXOP_SPACE so that they
count towards the total track time.
