### PR TITLE
Add install rule and fix some build system issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 .project
 /.ninja*
 /brother120tool
-/brother240tool
-/fluxengine
 /brother120tool-*
+/brother240tool
 /brother240tool-*
+/fluxengine
 /fluxengine-*
+/upgrade-flux-file

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,10 @@ CXXFLAGS += -std=c++17
 LDFLAGS ?=
 PLATFORM ?= UNIX
 TESTS ?= yes
-EXT ?= 
+EXT ?=
+DESTDIR ?=
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
 
 CFLAGS += \
 	-Iarch \
@@ -84,7 +87,7 @@ $(1): private LDFLAGS += $(shell $(PKG_CONFIG) --libs $(3))
 $(2): private CFLAGS += $(shell $(PKG_CONFIG) --cflags $(3))
 endef
 
-.PHONY: all tests
+.PHONY: all binaries tests clean install install-bin
 all: binaries tests
 
 PROTOS = \
@@ -221,5 +224,12 @@ $(OBJDIR)/%.pb.h: %.proto
 clean:
 	rm -rf $(OBJDIR)
 
--include $(OBJS:%.o=%.d)
+install: install-bin # install-man install-docs ...
 
+install-bin: fluxengine$(EXT) fluxengine-gui$(EXT) brother120tool$(EXT) brother240tool$(EXT) upgrade-flux-file$(EXT)
+	install -d "$(DESTDIR)$(BINDIR)"
+	for target in $^; do \
+		install $$target "$(DESTDIR)$(BINDIR)/$$target"; \
+	done
+
+-include $(OBJS:%.o=%.d)

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,9 @@ endif
 OBJDIR ?= .obj
 CCPREFIX ?=
 LUA ?= lua
-CC = $(CCPREFIX)gcc
-CXX = $(CCPREFIX)g++
-AR = $(CCPREFIX)ar
+CC ?= $(CCPREFIX)gcc
+CXX ?= $(CCPREFIX)g++
+AR ?= $(CCPREFIX)ar
 PKG_CONFIG ?= pkg-config
 WX_CONFIG ?= wx-config
 PROTOC ?= protoc


### PR DESCRIPTION
The support configuration variables are based on common conventions.

Default install prefix is `/usr/local`. Currently only the binaries are installed.

For packaging for a distro something along these lines would be used:
```
make install DESTDIR=/tmp/pkg-staging-directory PREFIX=/usr
```

The reason to have an install rule instead of handling that locally in each distribution is that if new binaries, data etc are added, there is only one location that has to be updated, rather than every distro noticing and updating their build rules.

I did not spread out the rules for this in the subdirectories, as writing the code just at the top level reduced the number of lines changed, but that might be possible (I'm not much of a Makefile-expert however. I generally use CMake or similar for my own projects).

EDIT: In addition, a couple of small fixes were done to to the build system.