### PR TITLE
D88: Fix sector ID conditions when writing.

### DIFF
--- a/lib/imagewriter/d88imagewriter.cc
+++ b/lib/imagewriter/d88imagewriter.cc
@@ -65,7 +65,7 @@ public:
 			headerWriter.write_le32(trackOffset);
 			int side = track & 1;
 			std::vector<std::shared_ptr<const Sector>> sectors;
-			for (int sectorId = 0; sectorId < geometry.numSectors; sectorId++)
+			for (int sectorId = geometry.firstSector; sectorId <= geometry.numSectors; sectorId++)
 			{
 				const auto& sector = image.get(track >> 1, side, sectorId);
 				if (sector)


### PR DESCRIPTION
This was failing to write the last sector in the image.
