### PR TITLE
Error out if you're not using GNU Make 4.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,13 @@ ifeq ($(shell uname),Darwin)
 		-framework Foundation
 endif
 
+# Check the Make version.
+
+
+ifeq ($(findstring 4.,$(MAKE_VERSION)),)
+$(error You need GNU Make 4.x for this (if you're on OSX, use gmake).)
+endif
+
 # Normal settings.
 
 OBJDIR ?= .obj


### PR DESCRIPTION
This should avoid the weird error message if you use the default OSX make.