### PR TITLE
D88/NFD: Add physical layout before adding sector.

### DIFF
--- a/lib/imagereader/d88imagereader.cc
+++ b/lib/imagereader/d88imagereader.cc
@@ -194,11 +194,10 @@ public:
                 }
                 Bytes data(sectorSize);
                 inputFile.read((char*)data.begin(), data.size());
+                physical->add_sector(sectorId);
                 const auto& sector = image->put(track, head, sectorId);
                 sector->status = Sector::OK;
                 sector->data = data;
-
-                physical->add_sector(sectorId);
             }
 
             if (mediaFlag != 0x20)

--- a/lib/imagereader/nfdimagereader.cc
+++ b/lib/imagereader/nfdimagereader.cc
@@ -143,11 +143,10 @@ public:
                 }
                 Bytes data(sectorSize);
                 inputFile.read((char*)data.begin(), data.size());
+                physical->add_sector(sectorId);
                 const auto& sector = image->put(track, head, sectorId);
                 sector->status = Sector::OK;
                 sector->data = data;
-
-                physical->add_sector(sectorId);
             }
         }
 


### PR DESCRIPTION
Partially fixes #603, it is still busted if the number of
tracks is specified larger than what is in the image, which
used to work.
