### PR TITLE
Do some long needed proto cleanup

### DIFF
--- a/doc/filesystem.md
+++ b/doc/filesystem.md
@@ -82,7 +82,7 @@ default; for example, Macintosh HFS filesystems are common on 3.5" floppies. You
 can do this as follows:
 
 ```
-fluxengine format ibm1440 -f drive:1 --filesystem.machfs=
+fluxengine format ibm1440 -f drive:1 --filesystem.type=MACHFS
 ```
 
 Some filesystems won't work on some disks --- don't try this with Amiga FFS, for

--- a/lib/fluxsink/fluxsink.cc
+++ b/lib/fluxsink/fluxsink.cc
@@ -9,55 +9,85 @@
 
 std::unique_ptr<FluxSink> FluxSink::create(const FluxSinkProto& config)
 {
-	switch (config.dest_case())
-	{
-		case FluxSinkProto::kDrive:
-			return createHardwareFluxSink(config.drive());
+    switch (config.type())
+    {
+        case FluxSinkProto::DRIVE:
+            return createHardwareFluxSink(config.drive());
 
-		case FluxSinkProto::kA2R:
-			return createA2RFluxSink(config.a2r());
+        case FluxSinkProto::A2R:
+            return createA2RFluxSink(config.a2r());
 
-		case FluxSinkProto::kAu:
-			return createAuFluxSink(config.au());
+        case FluxSinkProto::AU:
+            return createAuFluxSink(config.au());
 
-		case FluxSinkProto::kVcd:
-			return createVcdFluxSink(config.vcd());
+        case FluxSinkProto::VCD:
+            return createVcdFluxSink(config.vcd());
 
-		case FluxSinkProto::kScp:
-			return createScpFluxSink(config.scp());
+        case FluxSinkProto::SCP:
+            return createScpFluxSink(config.scp());
 
-		case FluxSinkProto::kFl2:
-			return createFl2FluxSink(config.fl2());
+        case FluxSinkProto::FLUX:
+            return createFl2FluxSink(config.fl2());
 
-		default:
-			Error() << "bad output disk config";
-			return std::unique_ptr<FluxSink>();
-	}
+        default:
+            Error() << "bad output disk config";
+            return std::unique_ptr<FluxSink>();
+    }
 }
 
-void FluxSink::updateConfigForFilename(FluxSinkProto* proto, const std::string& filename)
+void FluxSink::updateConfigForFilename(
+    FluxSinkProto* proto, const std::string& filename)
 {
-	static const std::vector<std::pair<std::regex, std::function<void(const std::string&, FluxSinkProto*)>>> formats =
-	{
-		{ std::regex("^(.*\\.a2r)$"),  [](auto& s, auto* proto) { proto->mutable_a2r()->set_filename(s); }},
-		{ std::regex("^(.*\\.flux)$"), [](auto& s, auto* proto) { proto->mutable_fl2()->set_filename(s); }},
-		{ std::regex("^(.*\\.scp)$"),  [](auto& s, auto* proto) { proto->mutable_scp()->set_filename(s); }},
-		{ std::regex("^vcd:(.*)$"),    [](auto& s, auto* proto) { proto->mutable_vcd()->set_directory(s); }},
-		{ std::regex("^au:(.*)$"),     [](auto& s, auto* proto) { proto->mutable_au()->set_directory(s); }},
-		{ std::regex("^drive:(.*)"),   [](auto& s, auto* proto) { proto->mutable_drive(); config.mutable_drive()->set_drive(std::stoi(s)); }},
-	};
+    static const std::vector<std::pair<std::regex,
+        std::function<void(const std::string&, FluxSinkProto*)>>>
+        formats = {
+            {std::regex("^(.*\\.a2r)$"),
+             [](auto& s, auto* proto)
+                {
+                    proto->set_type(FluxSinkProto::A2R);
+                    proto->mutable_a2r()->set_filename(s);
+                }},
+            {std::regex("^(.*\\.flux)$"),
+             [](auto& s, auto* proto)
+                {
+                    proto->set_type(FluxSinkProto::FLUX);
+                    proto->mutable_fl2()->set_filename(s);
+                }},
+            {std::regex("^(.*\\.scp)$"),
+             [](auto& s, auto* proto)
+                {
+                    proto->set_type(FluxSinkProto::SCP);
+                    proto->mutable_scp()->set_filename(s);
+                }},
+            {std::regex("^vcd:(.*)$"),
+             [](auto& s, auto* proto)
+                {
+                    proto->set_type(FluxSinkProto::VCD);
+                    proto->mutable_vcd()->set_directory(s);
+                }},
+            {std::regex("^au:(.*)$"),
+             [](auto& s, auto* proto)
+                {
+                    proto->set_type(FluxSinkProto::AU);
+                    proto->mutable_au()->set_directory(s);
+                }},
+            {std::regex("^drive:(.*)"),
+             [](auto& s, auto* proto)
+                {
+                    proto->set_type(FluxSinkProto::DRIVE);
+                    config.mutable_drive()->set_drive(std::stoi(s));
+                }},
+    };
 
-	for (const auto& it : formats)
-	{
-		std::smatch match;
-		if (std::regex_match(filename, match, it.first))
-		{
-			it.second(match[1], proto);
-			return;
-		}
-	}
+    for (const auto& it : formats)
+    {
+        std::smatch match;
+        if (std::regex_match(filename, match, it.first))
+        {
+            it.second(match[1], proto);
+            return;
+        }
+    }
 
-	Error() << fmt::format("unrecognised flux filename '{}'", filename);
+    Error() << fmt::format("unrecognised flux filename '{}'", filename);
 }
-
-

--- a/lib/fluxsink/fluxsink.proto
+++ b/lib/fluxsink/fluxsink.proto
@@ -14,7 +14,7 @@ message A2RFluxSinkProto {
 }
 
 message VcdFluxSinkProto {
-	optional string directory = 1 [default = "vcdfiles", (help) = "directory to write .vcd files to"];
+	optional string directory = 1 	   [default = "vcdfiles", (help) = "directory to write .vcd files to"];
 }
 
 message ScpFluxSinkProto {
@@ -27,15 +27,25 @@ message Fl2FluxSinkProto {
 	optional string filename = 1       [default = "flux.fl2", (help) = ".fl2 file to write to"];
 }
 
-// Next: 9
+// Next: 10
 message FluxSinkProto {
-	oneof dest {
-		HardwareFluxSinkProto drive = 2;
-		A2RFluxSinkProto a2r = 8;
-		AuFluxSinkProto au = 3;
-		VcdFluxSinkProto vcd = 4;
-		ScpFluxSinkProto scp = 5;
-		Fl2FluxSinkProto fl2 = 6;
+	enum FluxSinkType {
+		NOT_SET = 0;
+		DRIVE = 1;
+		A2R = 2;
+		AU = 3;
+		VCD = 4;
+		SCP = 5;
+		FLUX = 6;
 	}
+
+	optional FluxSinkType type = 9 [default = NOT_SET, (help) = "flux sink type"];
+
+	optional HardwareFluxSinkProto drive = 2;
+	optional A2RFluxSinkProto a2r = 8;
+	optional AuFluxSinkProto au = 3;
+	optional VcdFluxSinkProto vcd = 4;
+	optional ScpFluxSinkProto scp = 5;
+	optional Fl2FluxSinkProto fl2 = 6;
 }
 

--- a/lib/fluxsource/fluxsource.cc
+++ b/lib/fluxsource/fluxsource.cc
@@ -17,93 +17,128 @@ static bool ends_with(const std::string& value, const std::string& ending)
 
 std::unique_ptr<FluxSource> FluxSource::create(const FluxSourceProto& config)
 {
-	switch (config.source_case())
-	{
-		case FluxSourceProto::kDrive:
-			return createHardwareFluxSource(config.drive());
+    switch (config.type())
+    {
+        case FluxSourceProto::DRIVE:
+            return createHardwareFluxSource(config.drive());
 
-		case FluxSourceProto::kErase:
-			return createEraseFluxSource(config.erase());
+        case FluxSourceProto::ERASE:
+            return createEraseFluxSource(config.erase());
 
-		case FluxSourceProto::kKryoflux:
-			return createKryofluxFluxSource(config.kryoflux());
+        case FluxSourceProto::KRYOFLUX:
+            return createKryofluxFluxSource(config.kryoflux());
 
-		case FluxSourceProto::kTestPattern:
-			return createTestPatternFluxSource(config.test_pattern());
+        case FluxSourceProto::TEST_PATTERN:
+            return createTestPatternFluxSource(config.test_pattern());
 
-		case FluxSourceProto::kScp:
-			return createScpFluxSource(config.scp());
+        case FluxSourceProto::SCP:
+            return createScpFluxSource(config.scp());
 
-		case FluxSourceProto::kCwf:
-			return createCwfFluxSource(config.cwf());
+        case FluxSourceProto::CWF:
+            return createCwfFluxSource(config.cwf());
 
-		case FluxSourceProto::kFl2:
-			return createFl2FluxSource(config.fl2());
+        case FluxSourceProto::FLUX:
+            return createFl2FluxSource(config.fl2());
 
-		default:
-			Error() << "bad input disk configuration";
-			return std::unique_ptr<FluxSource>();
-	}
+        default:
+            Error() << "bad input disk configuration";
+            return std::unique_ptr<FluxSource>();
+    }
 }
 
-void FluxSource::updateConfigForFilename(FluxSourceProto* proto, const std::string& filename)
+void FluxSource::updateConfigForFilename(
+    FluxSourceProto* proto, const std::string& filename)
 {
 
-	static const std::vector<std::pair<std::regex, std::function<void(const std::string&, FluxSourceProto*)>>> formats =
-	{
-		{ std::regex("^(.*\\.a2r)$"),  [](auto& s, auto* proto) { }},
-		{ std::regex("^(.*\\.flux)$"),     [](auto& s, auto* proto) { proto->mutable_fl2()->set_filename(s); }},
-		{ std::regex("^(.*\\.scp)$"),      [](auto& s, auto* proto) { proto->mutable_scp()->set_filename(s); }},
-		{ std::regex("^(.*\\.cwf)$"),      [](auto& s, auto* proto) { proto->mutable_cwf()->set_filename(s); }},
-		{ std::regex("^erase:$"),          [](auto& s, auto* proto) { proto->mutable_erase(); }},
-		{ std::regex("^kryoflux:(.*)$"),   [](auto& s, auto* proto) { proto->mutable_kryoflux()->set_directory(s); }},
-		{ std::regex("^testpattern:(.*)"), [](auto& s, auto* proto) { proto->mutable_test_pattern(); }},
-		{ std::regex("^drive:(.*)"),       [](auto& s, auto* proto) { proto->mutable_drive(); config.mutable_drive()->set_drive(std::stoi(s)); }},
-	};
+    static const std::vector<std::pair<std::regex,
+        std::function<void(const std::string&, FluxSourceProto*)>>>
+        formats = {
+            {std::regex("^(.*\\.flux)$"),
+             [](auto& s, auto* proto)
+                {
+                    proto->set_type(FluxSourceProto::FLUX);
+                    proto->mutable_fl2()->set_filename(s);
+                }},
+            {std::regex("^(.*\\.scp)$"),
+             [](auto& s, auto* proto)
+                {
+                    proto->set_type(FluxSourceProto::SCP);
+                    proto->mutable_scp()->set_filename(s);
+                }},
+            {std::regex("^(.*\\.cwf)$"),
+             [](auto& s, auto* proto)
+                {
+                    proto->set_type(FluxSourceProto::CWF);
+                    proto->mutable_cwf()->set_filename(s);
+                }},
+            {std::regex("^erase:$"),
+             [](auto& s, auto* proto)
+                {
+                    proto->set_type(FluxSourceProto::ERASE);
+                }},
+            {std::regex("^kryoflux:(.*)$"),
+             [](auto& s, auto* proto)
+                {
+                    proto->set_type(FluxSourceProto::KRYOFLUX);
+                    proto->mutable_kryoflux()->set_directory(s);
+                }},
+            {std::regex("^testpattern:(.*)"),
+             [](auto& s, auto* proto)
+                {
+                    proto->set_type(FluxSourceProto::TEST_PATTERN);
+                }},
+            {std::regex("^drive:(.*)"),
+             [](auto& s, auto* proto)
+                {
+                    proto->set_type(FluxSourceProto::DRIVE);
+                    config.mutable_drive()->set_drive(std::stoi(s));
+                }},
+    };
 
-	for (const auto& it : formats)
-	{
-		std::smatch match;
-		if (std::regex_match(filename, match, it.first))
-		{
-			it.second(match[1], proto);
-			return;
-		}
-	}
+    for (const auto& it : formats)
+    {
+        std::smatch match;
+        if (std::regex_match(filename, match, it.first))
+        {
+            it.second(match[1], proto);
+            return;
+        }
+    }
 
-	Error() << fmt::format("unrecognised flux filename '{}'", filename);
+    Error() << fmt::format("unrecognised flux filename '{}'", filename);
 }
 
 class TrivialFluxSourceIterator : public FluxSourceIterator
 {
 public:
-	TrivialFluxSourceIterator(TrivialFluxSource* fluxSource, int track, int head):
-		_fluxSource(fluxSource),
-		_track(track),
-		_head(head)
-	{}
+    TrivialFluxSourceIterator(
+        TrivialFluxSource* fluxSource, int track, int head):
+        _fluxSource(fluxSource),
+        _track(track),
+        _head(head)
+    {
+    }
 
-	bool hasNext() const override
-	{
-		return !!_fluxSource;
-	}
+    bool hasNext() const override
+    {
+        return !!_fluxSource;
+    }
 
-	std::unique_ptr<const Fluxmap> next() override
-	{
-		auto fluxmap = _fluxSource->readSingleFlux(_track, _head);
-		_fluxSource = nullptr;
-		return fluxmap;
-	}
+    std::unique_ptr<const Fluxmap> next() override
+    {
+        auto fluxmap = _fluxSource->readSingleFlux(_track, _head);
+        _fluxSource = nullptr;
+        return fluxmap;
+    }
 
 private:
-	TrivialFluxSource* _fluxSource;
-	int _track;
-	int _head;
+    TrivialFluxSource* _fluxSource;
+    int _track;
+    int _head;
 };
 
-std::unique_ptr<FluxSourceIterator> TrivialFluxSource::readFlux(int track, int head)
+std::unique_ptr<FluxSourceIterator> TrivialFluxSource::readFlux(
+    int track, int head)
 {
-	return std::make_unique<TrivialFluxSourceIterator>(this, track, head);
+    return std::make_unique<TrivialFluxSourceIterator>(this, track, head);
 }
-
-

--- a/lib/fluxsource/fluxsource.proto
+++ b/lib/fluxsource/fluxsource.proto
@@ -30,15 +30,27 @@ message Fl2FluxSourceProto {
 		(help) = ".fl2 file to read flux from"];
 }
 
+// NEXT: 10
 message FluxSourceProto {
-	oneof source {
-		HardwareFluxSourceProto drive = 2;
-		TestPatternFluxSourceProto test_pattern = 3;
-		EraseFluxSourceProto erase = 4;
-		KryofluxFluxSourceProto kryoflux = 5;
-		ScpFluxSourceProto scp = 6;
-		CwfFluxSourceProto cwf = 7;
-		Fl2FluxSourceProto fl2 = 8;
+	enum FluxSourceType {
+		NOT_SET = 0;
+		DRIVE = 1;
+		TEST_PATTERN = 2;
+		ERASE = 3;
+		KRYOFLUX = 4;
+		SCP = 5;
+		CWF = 6;
+		FLUX = 7;
 	}
+
+	optional FluxSourceType type = 9 [default = NOT_SET, (help) = "flux source type"];
+
+	optional HardwareFluxSourceProto drive = 2;
+	optional TestPatternFluxSourceProto test_pattern = 3;
+	optional EraseFluxSourceProto erase = 4;
+	optional KryofluxFluxSourceProto kryoflux = 5;
+	optional ScpFluxSourceProto scp = 6;
+	optional CwfFluxSourceProto cwf = 7;
+	optional Fl2FluxSourceProto fl2 = 8;
 }
 

--- a/lib/imagereader/imagereader.cc
+++ b/lib/imagereader/imagereader.cc
@@ -14,39 +14,39 @@
 
 std::unique_ptr<ImageReader> ImageReader::create(const ImageReaderProto& config)
 {
-    switch (config.format_case())
+    switch (config.type())
     {
-        case ImageReaderProto::kDim:
+        case ImageReaderProto::DIM:
             return ImageReader::createDimImageReader(config);
 
-        case ImageReaderProto::kD88:
+        case ImageReaderProto::D88:
             return ImageReader::createD88ImageReader(config);
 
-        case ImageReaderProto::kFdi:
+        case ImageReaderProto::FDI:
             return ImageReader::createFdiImageReader(config);
 
-        case ImageReaderProto::kImd:
+        case ImageReaderProto::IMD:
             return ImageReader::createIMDImageReader(config);
 
-        case ImageReaderProto::kImg:
+        case ImageReaderProto::IMG:
             return ImageReader::createImgImageReader(config);
 
-        case ImageReaderProto::kDiskcopy:
+        case ImageReaderProto::DISKCOPY:
             return ImageReader::createDiskCopyImageReader(config);
 
-        case ImageReaderProto::kJv3:
+        case ImageReaderProto::JV3:
             return ImageReader::createJv3ImageReader(config);
 
-        case ImageReaderProto::kD64:
+        case ImageReaderProto::D64:
             return ImageReader::createD64ImageReader(config);
 
-        case ImageReaderProto::kNfd:
+        case ImageReaderProto::NFD:
             return ImageReader::createNFDImageReader(config);
 
-        case ImageReaderProto::kNsi:
+        case ImageReaderProto::NSI:
             return ImageReader::createNsiImageReader(config);
 
-        case ImageReaderProto::kTd0:
+        case ImageReaderProto::TD0:
             return ImageReader::createTd0ImageReader(config);
 
         default:
@@ -61,23 +61,23 @@ void ImageReader::updateConfigForFilename(
     static const std::map<std::string, std::function<void(ImageReaderProto*)>>
         formats = {
   // clang-format off
-		{".adf",      [](auto* proto) { proto->mutable_img(); }},
-		{".d64",      [](auto* proto) { proto->mutable_d64(); }},
-		{".d81",      [](auto* proto) { proto->mutable_img(); }},
-		{".d88",      [](auto* proto) { proto->mutable_d88(); }},
-		{".dim",      [](auto* proto) { proto->mutable_dim(); }},
-		{".diskcopy", [](auto* proto) { proto->mutable_diskcopy(); }},
-		{".dsk",      [](auto* proto) { proto->mutable_img(); }},
-		{".fdi",      [](auto* proto) { proto->mutable_fdi(); }},
-		{".imd",      [](auto* proto) { proto->mutable_imd(); }},
-		{".img",      [](auto* proto) { proto->mutable_img(); }},
-		{".jv3",      [](auto* proto) { proto->mutable_jv3(); }},
-		{".nfd",      [](auto* proto) { proto->mutable_nfd(); }},
-		{".nsi",      [](auto* proto) { proto->mutable_nsi(); }},
-		{".st",       [](auto* proto) { proto->mutable_img(); }},
-		{".td0",      [](auto* proto) { proto->mutable_td0(); }},
-		{".vgi",      [](auto* proto) { proto->mutable_img(); }},
-		{".xdf",      [](auto* proto) { proto->mutable_img(); }},
+		{".adf",      [](auto* proto) { proto->set_type(ImageReaderProto::IMG); }},
+		{".d64",      [](auto* proto) { proto->set_type(ImageReaderProto::D64); }},
+		{".d81",      [](auto* proto) { proto->set_type(ImageReaderProto::IMG); }},
+		{".d88",      [](auto* proto) { proto->set_type(ImageReaderProto::D88); }},
+		{".dim",      [](auto* proto) { proto->set_type(ImageReaderProto::DIM); }},
+		{".diskcopy", [](auto* proto) { proto->set_type(ImageReaderProto::DISKCOPY); }},
+		{".dsk",      [](auto* proto) { proto->set_type(ImageReaderProto::IMG); }},
+		{".fdi",      [](auto* proto) { proto->set_type(ImageReaderProto::FDI); }},
+		{".imd",      [](auto* proto) { proto->set_type(ImageReaderProto::IMD); }},
+		{".img",      [](auto* proto) { proto->set_type(ImageReaderProto::IMG); }},
+		{".jv3",      [](auto* proto) { proto->set_type(ImageReaderProto::JV3); }},
+		{".nfd",      [](auto* proto) { proto->set_type(ImageReaderProto::NFD); }},
+		{".nsi",      [](auto* proto) { proto->set_type(ImageReaderProto::NSI); }},
+		{".st",       [](auto* proto) { proto->set_type(ImageReaderProto::IMG); }},
+		{".td0",      [](auto* proto) { proto->set_type(ImageReaderProto::TD0); }},
+		{".vgi",      [](auto* proto) { proto->set_type(ImageReaderProto::IMG); }},
+		{".xdf",      [](auto* proto) { proto->set_type(ImageReaderProto::IMG); }},
   // clang-format on
     };
 

--- a/lib/imagereader/imagereader.proto
+++ b/lib/imagereader/imagereader.proto
@@ -13,9 +13,9 @@ message Td0InputProto {}
 message DimInputProto {}
 message FdiInputProto {}
 message D88InputProto {}
-message NFDInputProto {}
+message NfdInputProto {}
 
-// NEXT_TAG: 14
+// NEXT_TAG: 15
 message ImageReaderProto
 {
     optional string filename = 1 [ (help) = "filename of input sector image" ];
@@ -24,18 +24,32 @@ message ImageReaderProto
         default = false
     ];
 
-    oneof format
-    {
-        ImgInputOutputProto img = 2;
-        DiskCopyInputProto diskcopy = 3;
-        ImdInputProto imd = 4;
-        Jv3InputProto jv3 = 5;
-        D64InputProto d64 = 6;
-        NsiInputProto nsi = 7;
-        Td0InputProto td0 = 8;
-        DimInputProto dim = 9;
-        FdiInputProto fdi = 10;
-        D88InputProto d88 = 11;
-        NFDInputProto nfd = 12;
-    }
+	enum ImageReaderType {
+		NOT_SET = 0;
+		IMG = 1;
+		DISKCOPY = 2;
+		IMD = 3;
+		JV3 = 4;
+		D64 = 5;
+		NSI = 6;
+		TD0 = 7;
+		DIM = 8;
+		FDI = 9;
+		D88 = 10;
+		NFD = 11;
+	}
+
+	optional ImageReaderType type = 14 [default = NOT_SET, (help) = "input image type"];
+
+	optional ImgInputOutputProto img = 2;
+	optional DiskCopyInputProto diskcopy = 3;
+	optional ImdInputProto imd = 4;
+	optional Jv3InputProto jv3 = 5;
+	optional D64InputProto d64 = 6;
+	optional NsiInputProto nsi = 7;
+	optional Td0InputProto td0 = 8;
+	optional DimInputProto dim = 9;
+	optional FdiInputProto fdi = 10;
+	optional D88InputProto d88 = 11;
+	optional NfdInputProto nfd = 12;
 }

--- a/lib/imagewriter/imagewriter.cc
+++ b/lib/imagewriter/imagewriter.cc
@@ -14,30 +14,30 @@
 
 std::unique_ptr<ImageWriter> ImageWriter::create(const ImageWriterProto& config)
 {
-    switch (config.format_case())
+    switch (config.type())
     {
-        case ImageWriterProto::kImg:
+        case ImageWriterProto::IMG:
             return ImageWriter::createImgImageWriter(config);
 
-        case ImageWriterProto::kD64:
+        case ImageWriterProto::D64:
             return ImageWriter::createD64ImageWriter(config);
 
-        case ImageWriterProto::kLdbs:
+        case ImageWriterProto::LDBS:
             return ImageWriter::createLDBSImageWriter(config);
 
-        case ImageWriterProto::kDiskcopy:
+        case ImageWriterProto::DISKCOPY:
             return ImageWriter::createDiskCopyImageWriter(config);
 
-        case ImageWriterProto::kNsi:
+        case ImageWriterProto::NSI:
             return ImageWriter::createNsiImageWriter(config);
 
-        case ImageWriterProto::kRaw:
+        case ImageWriterProto::RAW:
             return ImageWriter::createRawImageWriter(config);
 
-        case ImageWriterProto::kD88:
+        case ImageWriterProto::D88:
             return ImageWriter::createD88ImageWriter(config);
 
-        case ImageWriterProto::kImd:
+        case ImageWriterProto::IMD:
             return ImageWriter::createImdImageWriter(config);
 
         default:
@@ -52,20 +52,20 @@ void ImageWriter::updateConfigForFilename(
     static const std::map<std::string, std::function<void(ImageWriterProto*)>>
         formats = {
   // clang-format off
-		{".adf",      [](auto* proto) { proto->mutable_img(); }},
-		{".d64",      [](auto* proto) { proto->mutable_d64(); }},
-		{".d81",      [](auto* proto) { proto->mutable_img(); }},
-		{".d88",      [](auto* proto) { proto->mutable_d88(); }},
-		{".diskcopy", [](auto* proto) { proto->mutable_diskcopy(); }},
-		{".dsk",      [](auto* proto) { proto->mutable_img(); }},
-		{".img",      [](auto* proto) { proto->mutable_img(); }},
-		{".imd",      [](auto* proto) { proto->mutable_imd(); }},
-		{".ldbs",     [](auto* proto) { proto->mutable_ldbs(); }},
-		{".nsi",      [](auto* proto) { proto->mutable_nsi(); }},
-		{".raw",      [](auto* proto) { proto->mutable_raw(); }},
-		{".st",       [](auto* proto) { proto->mutable_img(); }},
-		{".vgi",      [](auto* proto) { proto->mutable_img(); }},
-		{".xdf",      [](auto* proto) { proto->mutable_img(); }},
+		{".adf",      [](auto* proto) { proto->set_type(ImageWriterProto::IMG); }},
+		{".d64",      [](auto* proto) { proto->set_type(ImageWriterProto::D64); }},
+		{".d81",      [](auto* proto) { proto->set_type(ImageWriterProto::IMG); }},
+		{".d88",      [](auto* proto) { proto->set_type(ImageWriterProto::D88); }},
+		{".diskcopy", [](auto* proto) { proto->set_type(ImageWriterProto::DISKCOPY); }},
+		{".dsk",      [](auto* proto) { proto->set_type(ImageWriterProto::IMG); }},
+		{".img",      [](auto* proto) { proto->set_type(ImageWriterProto::IMG); }},
+		{".imd",      [](auto* proto) { proto->set_type(ImageWriterProto::IMD); }},
+		{".ldbs",     [](auto* proto) { proto->set_type(ImageWriterProto::LDBS); }},
+		{".nsi",      [](auto* proto) { proto->set_type(ImageWriterProto::NSI); }},
+		{".raw",      [](auto* proto) { proto->set_type(ImageWriterProto::RAW); }},
+		{".st",       [](auto* proto) { proto->set_type(ImageWriterProto::IMG); }},
+		{".vgi",      [](auto* proto) { proto->set_type(ImageWriterProto::IMG); }},
+		{".xdf",      [](auto* proto) { proto->set_type(ImageWriterProto::IMG); }},
   // clang-format on
     };
 

--- a/lib/imagewriter/imagewriter.proto
+++ b/lib/imagewriter/imagewriter.proto
@@ -63,24 +63,35 @@ message ImdOutputProto
     optional string comment = 3 [ (help) = "comment to set in IMD file" ];
 }
 
-// NEXT_TAG: 11
+// NEXT_TAG: 12
 message ImageWriterProto
 {
+    enum ImageWriterType {
+        NOT_SET = 0;
+        IMG = 1;
+        D64 = 2;
+        LDBS = 3;
+        DISKCOPY = 4;
+        NSI = 5;
+        RAW = 6;
+        D88 = 7;
+        IMD = 8;
+    }
+
     optional string filename = 1 [ (help) = "filename of output sector image" ];
     optional bool filesystem_sector_order = 10 [
         (help) = "read/write sector image in filesystem order",
         default = false
     ];
 
-    oneof format
-    {
-        ImgInputOutputProto img = 2;
-        D64OutputProto d64 = 3;
-        LDBSOutputProto ldbs = 4;
-        DiskCopyOutputProto diskcopy = 5;
-        NsiOutputProto nsi = 6;
-        RawOutputProto raw = 7;
-        D88OutputProto d88 = 8;
-        ImdOutputProto imd = 9;
-    }
+    optional ImageWriterType type = 11 [ default = NOT_SET, (help) = "image writer type" ];
+
+    optional ImgInputOutputProto img = 2;
+    optional D64OutputProto d64 = 3;
+    optional LDBSOutputProto ldbs = 4;
+    optional DiskCopyOutputProto diskcopy = 5;
+    optional NsiOutputProto nsi = 6;
+    optional RawOutputProto raw = 7;
+    optional D88OutputProto d88 = 8;
+    optional ImdOutputProto imd = 9;
 }

--- a/lib/vfs/vfs.cc
+++ b/lib/vfs/vfs.cc
@@ -177,30 +177,30 @@ Filesystem::Filesystem(std::shared_ptr<SectorInterface> sectors):
 std::unique_ptr<Filesystem> Filesystem::createFilesystem(
     const FilesystemProto& config, std::shared_ptr<SectorInterface> image)
 {
-    switch (config.filesystem_case())
+    switch (config.type())
     {
-        case FilesystemProto::kBrother120:
+        case FilesystemProto::BROTHER120:
             return Filesystem::createBrother120Filesystem(config, image);
 
-        case FilesystemProto::kAcorndfs:
+        case FilesystemProto::ACORNDFS:
             return Filesystem::createAcornDfsFilesystem(config, image);
 
-        case FilesystemProto::kFatfs:
+        case FilesystemProto::FATFS:
             return Filesystem::createFatFsFilesystem(config, image);
 
-        case FilesystemProto::kCpmfs:
+        case FilesystemProto::CPMFS:
             return Filesystem::createCpmFsFilesystem(config, image);
 
-        case FilesystemProto::kAmigaffs:
+        case FilesystemProto::AMIGAFFS:
             return Filesystem::createAmigaFfsFilesystem(config, image);
 
-        case FilesystemProto::kMachfs:
+        case FilesystemProto::MACHFS:
             return Filesystem::createMacHfsFilesystem(config, image);
 
-        case FilesystemProto::kCbmfs:
+        case FilesystemProto::CBMFS:
             return Filesystem::createCbmfsFilesystem(config, image);
 
-        case FilesystemProto::kProdos:
+        case FilesystemProto::PRODOS:
             return Filesystem::createProdosFilesystem(config, image);
 
         default:

--- a/lib/vfs/vfs.cc
+++ b/lib/vfs/vfs.cc
@@ -218,13 +218,13 @@ std::unique_ptr<Filesystem> Filesystem::createFilesystemFromConfig()
         std::shared_ptr<Decoder> decoder;
         std::shared_ptr<FluxSink> fluxSink;
         std::shared_ptr<Encoder> encoder;
-        if (config.flux_source().source_case() !=
-            FluxSourceProto::SOURCE_NOT_SET)
+        if (config.flux_source().type() !=
+            FluxSourceProto::NOT_SET)
         {
             fluxSource = FluxSource::create(config.flux_source());
             decoder = Decoder::create(config.decoder());
         }
-        if (config.flux_sink().has_drive())
+        if (config.flux_sink().type() == FluxSinkProto::DRIVE)
         {
             fluxSink = FluxSink::create(config.flux_sink());
             encoder = Encoder::create(config.encoder());

--- a/lib/vfs/vfs.cc
+++ b/lib/vfs/vfs.cc
@@ -218,8 +218,7 @@ std::unique_ptr<Filesystem> Filesystem::createFilesystemFromConfig()
         std::shared_ptr<Decoder> decoder;
         std::shared_ptr<FluxSink> fluxSink;
         std::shared_ptr<Encoder> encoder;
-        if (config.flux_source().type() !=
-            FluxSourceProto::NOT_SET)
+        if (config.flux_source().type() != FluxSourceProto::NOT_SET)
         {
             fluxSource = FluxSource::create(config.flux_source());
             decoder = Decoder::create(config.decoder());
@@ -236,11 +235,9 @@ std::unique_ptr<Filesystem> Filesystem::createFilesystemFromConfig()
     {
         std::shared_ptr<ImageReader> reader;
         std::shared_ptr<ImageWriter> writer;
-        if (config.image_reader().format_case() !=
-            ImageReaderProto::FORMAT_NOT_SET)
+        if (config.image_reader().type() != ImageReaderProto::NOT_SET)
             reader = ImageReader::create(config.image_reader());
-        if (config.image_writer().format_case() !=
-            ImageWriterProto::FORMAT_NOT_SET)
+        if (config.image_writer().type() != ImageWriterProto::NOT_SET)
             writer = ImageWriter::create(config.image_writer());
 
         sectorInterface =

--- a/lib/vfs/vfs.proto
+++ b/lib/vfs/vfs.proto
@@ -59,20 +59,31 @@ message CbmfsProto
 
 message ProdosProto {}
 
-// NEXT_TAG: 10
+// NEXT_TAG: 11
 message FilesystemProto
 {
-    oneof filesystem
-    {
-        AcornDfsProto acorndfs = 1;
-        Brother120FsProto brother120 = 2;
-        FatFsProto fatfs = 3;
-        CpmFsProto cpmfs = 4;
-        AmigaFfsProto amigaffs = 5;
-        MacHfsProto machfs = 6;
-        CbmfsProto cbmfs = 7;
-        ProdosProto prodos = 8;
+    enum FilesystemType {
+        NOT_SET = 0;
+        ACORNDFS = 1;
+        BROTHER120 = 2;
+        FATFS = 3;
+        CPMFS = 4;
+        AMIGAFFS = 5;
+        MACHFS = 6;
+        CBMFS = 7;
+        PRODOS = 8;
     }
+
+    optional FilesystemType type = 10 [default = NOT_SET, (help) = "filesystem type"];
+
+    optional AcornDfsProto acorndfs = 1;
+    optional Brother120FsProto brother120 = 2;
+    optional FatFsProto fatfs = 3;
+    optional CpmFsProto cpmfs = 4;
+    optional AmigaFfsProto amigaffs = 5;
+    optional MacHfsProto machfs = 6;
+    optional CbmfsProto cbmfs = 7;
+    optional ProdosProto prodos = 8;
     
     optional SectorListProto sector_order = 9 [(help) = "specify the filesystem order of sectors"];
 }

--- a/src/fe-analysedriveresponse.cc
+++ b/src/fe-analysedriveresponse.cc
@@ -211,10 +211,10 @@ static void draw_x_graticules(Agg2D& painter, double x1, double y1, double x2, d
 
 int mainAnalyseDriveResponse(int argc, const char* argv[])
 {
-	config.mutable_flux_source()->mutable_drive();
+	config.mutable_flux_source()->set_type(FluxSourceProto::DRIVE);
     flags.parseFlagsWithConfigFiles(argc, argv, {});
 
-	if (!config.flux_sink().has_drive())
+	if (config.flux_sink().type() != FluxSinkProto::DRIVE)
 		Error() << "this only makes sense with a real disk drive";
 
     usbSetDrive(config.drive().drive(),

--- a/src/fe-inspect.cc
+++ b/src/fe-inspect.cc
@@ -210,7 +210,7 @@ static nanoseconds_t guessClock(const Fluxmap& fluxmap)
 
 int mainInspect(int argc, const char* argv[])
 {
-	config.mutable_flux_source()->mutable_drive();
+	config.mutable_flux_source()->set_type(FluxSourceProto::DRIVE);
     flags.parseFlagsWithConfigFiles(argc, argv, {});
 
 	std::unique_ptr<FluxSource> fluxSource(FluxSource::create(config.flux_source()));

--- a/src/fe-rawread.cc
+++ b/src/fe-rawread.cc
@@ -61,10 +61,10 @@ int mainRawRead(int argc, const char* argv[])
 
 	if (argc == 1)
 		showProfiles("rawread", formats);
-	config.mutable_flux_source()->mutable_drive();
+	config.mutable_flux_source()->set_type(FluxSourceProto::DRIVE);
     flags.parseFlagsWithConfigFiles(argc, argv, formats);
 
-	if (config.flux_sink().has_drive())
+	if (config.flux_sink().type() == FluxSinkProto::DRIVE)
 		Error() << "you can't use rawread to write to hardware";
 
 	std::unique_ptr<FluxSource> fluxSource(FluxSource::create(config.flux_source()));

--- a/src/fe-rawwrite.cc
+++ b/src/fe-rawwrite.cc
@@ -54,7 +54,7 @@ static ActionFlag eraseFlag(
 	"erases the destination",
 	[]()
 	{
-		config.mutable_flux_source()->mutable_erase();
+		config.mutable_flux_source()->set_type(FluxSourceProto::ERASE);
 	});
 
 int mainRawWrite(int argc, const char* argv[])
@@ -64,10 +64,10 @@ int mainRawWrite(int argc, const char* argv[])
 
 	if (argc == 1)
 		showProfiles("rawwrite", formats);
-	config.mutable_flux_sink()->mutable_drive();
+	config.mutable_flux_sink()->set_type(FluxSinkProto::DRIVE);
     flags.parseFlagsWithConfigFiles(argc, argv, formats);
 
-	if (config.flux_source().has_drive())
+	if (config.flux_source().type() == FluxSourceProto::DRIVE)
 		Error() << "you can't use rawwrite to read from hardware";
 
 	std::unique_ptr<FluxSource> fluxSource(FluxSource::create(config.flux_source()));

--- a/src/fe-read.cc
+++ b/src/fe-read.cc
@@ -70,7 +70,7 @@ int mainRead(int argc, const char* argv[])
 	config.mutable_flux_source()->set_type(FluxSourceProto::DRIVE);
     flags.parseFlagsWithConfigFiles(argc, argv, formats);
 
-	if (config.decoder().copy_flux_to().has_drive())
+	if (config.decoder().copy_flux_to().type() == FluxSinkProto::DRIVE)
 		Error() << "you cannot copy flux to a hardware device";
 
 	std::unique_ptr<FluxSource> fluxSource(FluxSource::create(config.flux_source()));

--- a/src/fe-read.cc
+++ b/src/fe-read.cc
@@ -67,7 +67,7 @@ int mainRead(int argc, const char* argv[])
 {
 	if (argc == 1)
 		showProfiles("read", formats);
-	config.mutable_flux_source()->mutable_drive();
+	config.mutable_flux_source()->set_type(FluxSourceProto::DRIVE);
     flags.parseFlagsWithConfigFiles(argc, argv, formats);
 
 	if (config.decoder().copy_flux_to().has_drive())

--- a/src/fe-rpm.cc
+++ b/src/fe-rpm.cc
@@ -20,7 +20,7 @@ int mainRpm(int argc, const char* argv[])
 {
     flags.parseFlagsWithConfigFiles(argc, argv, {});
 
-	if (!config.flux_source().has_drive())
+	if (!config.flux_source().type() != FluxSourceProto::DRIVE)
 		Error() << "this only makes sense with a real disk drive";
 
     usbSetDrive(config.drive().drive(), false, config.drive().index_mode());

--- a/src/fe-seek.cc
+++ b/src/fe-seek.cc
@@ -27,7 +27,7 @@ int mainSeek(int argc, const char* argv[])
 {
     flags.parseFlagsWithConfigFiles(argc, argv, {});
 
-	if (!config.flux_source().has_drive())
+	if (config.flux_source().type() != FluxSourceProto::DRIVE)
 		Error() << "this only makes sense with a real disk drive";
 
     usbSetDrive(config.drive().drive(), false, config.drive().index_mode());

--- a/src/fe-write.cc
+++ b/src/fe-write.cc
@@ -67,9 +67,9 @@ int mainWrite(int argc, const char* argv[])
 {
 	if (argc == 1)
 		showProfiles("write", formats);
-	config.mutable_flux_sink()->mutable_drive();
+	config.mutable_flux_sink()->set_type(FluxSinkProto::DRIVE);
 	if (verify)
-		config.mutable_flux_source()->mutable_drive();
+		config.mutable_flux_source()->set_type(FluxSourceProto::DRIVE);
     flags.parseFlagsWithConfigFiles(argc, argv, formats);
 
 	std::unique_ptr<ImageReader> reader(ImageReader::create(config.image_reader()));
@@ -83,7 +83,7 @@ int mainWrite(int argc, const char* argv[])
 		decoder = Decoder::create(config.decoder());
 
 	std::unique_ptr<FluxSource> fluxSource;
-	if (verify && config.has_flux_source() && config.flux_source().has_drive())
+	if (verify && (config.flux_source().type() == FluxSourceProto::DRIVE))
 		fluxSource = FluxSource::create(config.flux_source());
 
 	writeDiskCommand(*image, *encoder, *fluxSink, decoder.get(), fluxSource.get());

--- a/src/formats/_acornadfs32.textpb
+++ b/src/formats/_acornadfs32.textpb
@@ -3,7 +3,7 @@ is_extension: true
 
 image_writer {
 	filename: "acornadfs.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/_acornadfs8.textpb
+++ b/src/formats/_acornadfs8.textpb
@@ -3,7 +3,7 @@ is_extension: true
 
 image_writer {
 	filename: "acornadfs.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/_micropolis.textpb
+++ b/src/formats/_micropolis.textpb
@@ -7,12 +7,12 @@ drive {
 
 image_reader {
 	filename: "micropolis.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "micropolis.img"
-	img {}
+	type: IMG
 }
 
 layout {
@@ -41,12 +41,12 @@ option {
 	config {
 		image_reader {
 			filename: "micropolis.vgi"
-			img {}
+			type: IMG
 		}
 
 		image_writer {
 			filename: "micropolis.vgi"
-			img {}
+			type: IMG
 		}
 
 		layout {

--- a/src/formats/_mx.textpb
+++ b/src/formats/_mx.textpb
@@ -3,7 +3,7 @@ is_extension: true
 
 image_writer {
 	filename: "mx.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/_northstar.textpb
+++ b/src/formats/_northstar.textpb
@@ -3,12 +3,12 @@ is_extension: true
 
 image_reader {
 	filename: "northstar.nsi"
-	nsi {}
+	type: NSI
 }
 
 image_writer {
 	filename: "northstar.nsi"
-	nsi {}
+	type: NSI
 }
 
 layout {

--- a/src/formats/acorndfs.textpb
+++ b/src/formats/acorndfs.textpb
@@ -2,12 +2,12 @@ comment: 'Acorn DFS 100kB/200kB 3.5" or 5.25" 40- or 80-track SS (ro)'
 
 image_reader {
 	filename: "acorndfs.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "acorndfs.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/acorndfs.textpb
+++ b/src/formats/acorndfs.textpb
@@ -44,6 +44,6 @@ decoder {
 }
 
 filesystem {
-	acorndfs {}
+	type: ACORNDFS
 }
 

--- a/src/formats/aeslanier.textpb
+++ b/src/formats/aeslanier.textpb
@@ -2,7 +2,7 @@ comment: 'AES Lanier "No Problem" 616kB 5.25" 77-track SSDD hard sectored (ro)'
 
 image_writer {
 	filename: "aeslanier.img"
-	img {}
+	type: IMG
 }
 
 decoder {

--- a/src/formats/agat840.textpb
+++ b/src/formats/agat840.textpb
@@ -2,7 +2,7 @@ comment: 'Agat 840kB 5.25" 80-track DS (ro)'
 
 image_writer {
 	filename: "agat.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/amiga.textpb
+++ b/src/formats/amiga.textpb
@@ -2,12 +2,12 @@ comment: 'Amiga 880kB 3.5" DSDD'
 
 image_reader {
 	filename: "amiga.adf"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "amiga.adf"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/amiga.textpb
+++ b/src/formats/amiga.textpb
@@ -31,6 +31,6 @@ decoder {
 }
 
 filesystem {
-	amigaffs {}
+	type: AMIGAFFS
 }
 

--- a/src/formats/ampro400.textpb
+++ b/src/formats/ampro400.textpb
@@ -2,7 +2,7 @@ comment: 'Ampro 400kB/800kB 5.25" 40/80 track SSDD/DSDD (ro)'
 
 image_writer {
 	filename: "ampro.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/ampro800.textpb
+++ b/src/formats/ampro800.textpb
@@ -2,7 +2,7 @@ comment: 'Ampro 400kB/800kB 5.25" 40/80 track SSDD/DSDD (ro)'
 
 image_writer {
 	filename: "ampro.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/apple2.textpb
+++ b/src/formats/apple2.textpb
@@ -86,7 +86,7 @@ option {
 		}
 	
 		filesystem {
-			prodos {}
+			type: PRODOS
 		}
 
 		layout {

--- a/src/formats/apple2.textpb
+++ b/src/formats/apple2.textpb
@@ -2,7 +2,7 @@ comment: 'Apple II 140kB DOS 3.3 5.25" 40 track SSSD'
 
 image_reader {
 	filename: "apple2.img"
-	img {}
+	type: IMG
 }
 
 layout {
@@ -19,7 +19,7 @@ layout {
 
 image_writer {
 	filename: "apple2.img"
-	img {}
+	type: IMG
 }
 
 decoder {

--- a/src/formats/atarist360.textpb
+++ b/src/formats/atarist360.textpb
@@ -4,12 +4,12 @@ include: '_atari'
 
 image_reader {
 	filename: "atarist360.st"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "atarist360.st"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/atarist370.textpb
+++ b/src/formats/atarist370.textpb
@@ -4,12 +4,12 @@ include: '_atari'
 
 image_reader {
 	filename: "atarist370.st"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "atarist370.st"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/atarist400.textpb
+++ b/src/formats/atarist400.textpb
@@ -4,12 +4,12 @@ include: '_atari'
 
 image_reader {
 	filename: "atarist400.st"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "atarist400.st"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/atarist410.textpb
+++ b/src/formats/atarist410.textpb
@@ -4,12 +4,12 @@ include: '_atari'
 
 image_reader {
 	filename: "atarist410.st"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "atarist410.st"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/atarist720.textpb
+++ b/src/formats/atarist720.textpb
@@ -4,12 +4,12 @@ include: '_atari'
 
 image_reader {
 	filename: "atarist720.st"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "atarist720.st"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/atarist740.textpb
+++ b/src/formats/atarist740.textpb
@@ -4,12 +4,12 @@ include: '_atari'
 
 image_reader {
 	filename: "atarist740.st"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "atarist740.st"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/atarist800.textpb
+++ b/src/formats/atarist800.textpb
@@ -4,12 +4,12 @@ include: '_atari'
 
 image_reader {
 	filename: "atarist800.st"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "atarist800.st"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/atarist820.textpb
+++ b/src/formats/atarist820.textpb
@@ -4,12 +4,12 @@ include: '_atari'
 
 image_reader {
 	filename: "atarist820.st"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "atarist820.st"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/bk800.textpb
+++ b/src/formats/bk800.textpb
@@ -2,12 +2,12 @@ comment: 'BK 800kB 5.25"/3.5" 80-track 10-sector DSDD'
 
 image_reader {
 	filename: "bk800.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "bk800.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/brother120.textpb
+++ b/src/formats/brother120.textpb
@@ -41,6 +41,6 @@ drive {
 tpi: 48
 
 filesystem {
-	brother120 {}
+	type: BROTHER120
 }
 

--- a/src/formats/brother120.textpb
+++ b/src/formats/brother120.textpb
@@ -2,12 +2,12 @@ comment: 'Brother 120kB 3.5" 39-track SS GCR'
 
 image_reader {
 	filename: "brother120.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "brother120.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/brother240.textpb
+++ b/src/formats/brother240.textpb
@@ -36,6 +36,6 @@ drive {
 }
 
 filesystem {
-	fatfs {}
+	type: FATFS
 }
 

--- a/src/formats/brother240.textpb
+++ b/src/formats/brother240.textpb
@@ -2,12 +2,12 @@ comment: 'Brother 240kB 3.5" 78-track SS GCR'
 
 image_reader {
 	filename: "brother240.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "brother240.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/cmd_fd2000.textpb
+++ b/src/formats/cmd_fd2000.textpb
@@ -2,12 +2,12 @@ comment: 'CMD FD2000 1620kB 3.5" DSHD'
 
 image_reader {
 	filename: "cmd_fd2000.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "cmd_fd2000.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/commodore1541.textpb
+++ b/src/formats/commodore1541.textpb
@@ -2,12 +2,12 @@ comment: 'Commodore 1541 171kB/192kB 5.25" 35/40-track SS GCR'
 
 image_reader {
 	filename: "commodore1541.d64"
-	d64 {}
+	type: D64
 }
 
 image_writer {
 	filename: "commodore1541.d64"
-	d64 {}
+	type: D64
 }
 
 layout {

--- a/src/formats/commodore1541.textpb
+++ b/src/formats/commodore1541.textpb
@@ -61,7 +61,7 @@ decoder {
 tpi: 48
 
 filesystem {
-	cbmfs {}
+	type: CBMFS
 }
 
 option {

--- a/src/formats/commodore1581.textpb
+++ b/src/formats/commodore1581.textpb
@@ -2,12 +2,12 @@ comment: 'Commodore 1581 800kB 3.5" DSDD'
 
 image_reader {
 	filename: "commodore1581.d81"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "commodore1581.d81"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/eco1.textpb
+++ b/src/formats/eco1.textpb
@@ -2,7 +2,7 @@ comment: 'VDS Eco1 1210kB 77-track mixed format DSHD (ro)'
 
 image_writer {
 	filename: "eco1.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/eco1.textpb
+++ b/src/formats/eco1.textpb
@@ -42,6 +42,7 @@ decoder {
 }
 
 filesystem {
+	type: CPMFS
 	cpmfs {
 		filesystem_start {
 			track: 2

--- a/src/formats/epsonpf10.textpb
+++ b/src/formats/epsonpf10.textpb
@@ -24,6 +24,7 @@ decoder {
 tpi: 48
 
 filesystem {
+	type: CPMFS
 	cpmfs {
 		filesystem_start {
 			track: 4

--- a/src/formats/epsonpf10.textpb
+++ b/src/formats/epsonpf10.textpb
@@ -2,7 +2,7 @@ comment: 'Epson PF-10 40-track DS DD (ro)'
 
 image_writer {
 	filename: "epsonpf10.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/f85.textpb
+++ b/src/formats/f85.textpb
@@ -2,7 +2,7 @@ comment: 'Durango F85 461kB 5.25" 77-track SS (ro)'
 
 image_writer {
 	filename: "f85.img"
-	img {}
+	type: IMG
 }
 
 decoder {

--- a/src/formats/fb100.textpb
+++ b/src/formats/fb100.textpb
@@ -2,7 +2,7 @@ comment: 'Brother FB-100 100kB 3.5" 40-track SS (ro)'
 
 image_writer {
 	filename: "fb100.img"
-	img {}
+	type: IMG
 }
 
 decoder {

--- a/src/formats/hp9121.textpb
+++ b/src/formats/hp9121.textpb
@@ -2,7 +2,7 @@ comment: 'Hewlett-Packard 9121 264kB 3.5" SSDD'
 
 image_reader {
 	filename: "hp9121.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/hplif770.textpb
+++ b/src/formats/hplif770.textpb
@@ -7,12 +7,12 @@ drive {
 
 image_reader {
 	filename: "hplif770.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "hplif770.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/ibm.textpb
+++ b/src/formats/ibm.textpb
@@ -2,7 +2,7 @@ comment: 'PC 3.5"/5.25" autodetect double sided format'
 
 image_writer {
 	filename: "ibm.img"
-	img {}
+	type: IMG
 }
 
 decoder {

--- a/src/formats/ibm1200.textpb
+++ b/src/formats/ibm1200.textpb
@@ -40,7 +40,7 @@ drive {
 }
 
 filesystem {
-	fatfs {}
+	type: FATFS
 }
 
 

--- a/src/formats/ibm1200.textpb
+++ b/src/formats/ibm1200.textpb
@@ -2,12 +2,12 @@ comment: 'PC 1200kB 5.25" 80-track 15-sector DSHD'
 
 image_reader {
 	filename: "ibm1200.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "ibm1200.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/ibm1232.textpb
+++ b/src/formats/ibm1232.textpb
@@ -40,7 +40,7 @@ drive {
 }
 
 filesystem {
-	fatfs {}
+	type: FATFS
 }
 
 

--- a/src/formats/ibm1232.textpb
+++ b/src/formats/ibm1232.textpb
@@ -2,12 +2,12 @@ comment: 'Japanese PC 1232kB 5.25"/3.5" 77-track 8-sector DSHD'
 
 image_reader {
 	filename: "ibm1232.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "ibm1232.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/ibm1440.textpb
+++ b/src/formats/ibm1440.textpb
@@ -36,6 +36,6 @@ decoder {
 }
 
 filesystem {
-	fatfs {}
+	type: FATFS
 }
 

--- a/src/formats/ibm1440.textpb
+++ b/src/formats/ibm1440.textpb
@@ -2,12 +2,12 @@ comment: 'PC 1440kB 3.5" 80-track 18-sector DSHD'
 
 image_reader {
 	filename: "ibm1440.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "ibm1440.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/ibm180.textpb
+++ b/src/formats/ibm180.textpb
@@ -42,7 +42,7 @@ drive {
 tpi: 48
 
 filesystem {
-	fatfs {}
+	type: FATFS
 }
 
 

--- a/src/formats/ibm180.textpb
+++ b/src/formats/ibm180.textpb
@@ -2,12 +2,12 @@ comment: 'PC 180kB 5.25" 40-track 9-sector SSDD'
 
 image_reader {
 	filename: "ibm180.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "ibm180.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/ibm360.textpb
+++ b/src/formats/ibm360.textpb
@@ -2,12 +2,12 @@ comment: 'PC 360kB 5.25" 40-track 9-sector DSDD'
 
 image_reader {
 	filename: "ibm360.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "ibm360.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/ibm360.textpb
+++ b/src/formats/ibm360.textpb
@@ -38,7 +38,7 @@ decoder {
 tpi: 48
 
 filesystem {
-	fatfs {}
+	type: FATFS
 }
 
 

--- a/src/formats/ibm720.textpb
+++ b/src/formats/ibm720.textpb
@@ -2,12 +2,12 @@ comment: 'PC 720kB 5.25"/3.5" 80-track 9-sector DSDD'
 
 image_reader {
 	filename: "ibm720.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "ibm720.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/ibm720.textpb
+++ b/src/formats/ibm720.textpb
@@ -42,6 +42,6 @@ drive {
 }
 
 filesystem {
-	fatfs {}
+	type: FATFS
 }
 

--- a/src/formats/icl30.textpb
+++ b/src/formats/icl30.textpb
@@ -50,6 +50,7 @@ decoder {
 }
 
 filesystem {
+	type: CPMFS
 	cpmfs {
 		filesystem_start {
 			track: 1

--- a/src/formats/icl30.textpb
+++ b/src/formats/icl30.textpb
@@ -2,7 +2,7 @@ comment: 'ICL Model 30 263kB 34-track DSSD (ro)'
 
 image_writer {
 	filename: "icl30.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/mac400.textpb
+++ b/src/formats/mac400.textpb
@@ -2,12 +2,12 @@ comment: 'Macintosh 400kB 3.5" SSDD GCR'
 
 image_reader {
 	filename: "mac400.dsk"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "mac400.dsk"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/mac800.textpb
+++ b/src/formats/mac800.textpb
@@ -2,12 +2,12 @@ comment: 'Macintosh 800kB 3.5" DSDD GCR'
 
 image_reader {
 	filename: "mac800.dsk"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "mac800.dsk"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/mac800.textpb
+++ b/src/formats/mac800.textpb
@@ -65,7 +65,7 @@ decoder {
 }
 
 filesystem {
-	machfs {}
+	type: MACHFS
 }
 
 

--- a/src/formats/n88basic.textpb
+++ b/src/formats/n88basic.textpb
@@ -6,12 +6,12 @@ drive {
 
 image_reader {
 	filename: "n88basic.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "n88basic.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/rx50.textpb
+++ b/src/formats/rx50.textpb
@@ -6,12 +6,12 @@ drive {
 
 image_reader {
 	filename: "rx50.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "rx50.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/tids990.textpb
+++ b/src/formats/tids990.textpb
@@ -2,12 +2,12 @@ comment: 'Texas Instruments DS990 1126kB 8" DSSD'
 
 image_reader {
 	filename: "tids990.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "tids990.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/victor9k_ds.textpb
+++ b/src/formats/victor9k_ds.textpb
@@ -2,12 +2,12 @@ comment: 'Victor 9000 / Sirius One 1224kB DSHD GCR variable sector)'
 
 image_reader {
 	filename: "victor9k_ds.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "victor9k_ds.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/victor9k_ss.textpb
+++ b/src/formats/victor9k_ss.textpb
@@ -2,12 +2,12 @@ comment: 'Victor 9000 / Sirius One 612kB SSHD GCR variable sector)'
 
 image_reader {
 	filename: "victor9k.img"
-	img {}
+	type: IMG
 }
 
 image_writer {
 	filename: "victor9k.img"
-	img {}
+	type: IMG
 }
 
 layout {

--- a/src/formats/zilogmcz.textpb
+++ b/src/formats/zilogmcz.textpb
@@ -2,7 +2,7 @@ comment: 'Zilog MCZ 320kB 8" 77-track SS hard-sectored (ro)'
 
 image_writer {
 	filename: "zilogmcz.img"
-	img {}
+	type: IMG
 }
 
 decoder {


### PR DESCRIPTION
We want to stop using oneofs for the reader/writer/source/sink stuff in favour of an explicit type with an enum so that we can have default settings for multiple formats at once.