### PR TITLE
Fix a crash when using the GUI.

### DIFF
--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -5,8 +5,9 @@ static std::unique_ptr<std::set<LocalBase*>> variables;
 
 void Environment::reset()
 {
-    for (LocalBase* var : *variables)
-        var->reset();
+    if (variables)
+        for (LocalBase* var : *variables)
+            var->reset();
 }
 
 void Environment::addVariable(LocalBase* local)


### PR DESCRIPTION
An environment manager bug would cause a segfault when resetting the environment.

Fixes: #610 