### PR TITLE
Correct generation of SCP files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,11 +160,17 @@ include tests/build.mk
 do-encodedecodetest = $(eval $(do-encodedecodetest-impl))
 define do-encodedecodetest-impl
 
-tests: $(OBJDIR)/$1$3.encodedecode
-$(OBJDIR)/$1$3.encodedecode: scripts/encodedecodetest.sh $(FLUXENGINE_BIN) $2
+tests: $(OBJDIR)/$1$3.flux.encodedecode
+$(OBJDIR)/$1$3.flux.encodedecode: scripts/encodedecodetest.sh $(FLUXENGINE_BIN) $2
 	@mkdir -p $(dir $$@)
-	@echo ENCODEDECODETEST $1 $3
+	@echo ENCODEDECODETEST .flux $1 $3
 	@scripts/encodedecodetest.sh $1 flux $(FLUXENGINE_BIN) $2 $3 > $$@
+
+tests: $(OBJDIR)/$1$3.scp.encodedecode
+$(OBJDIR)/$1$3.scp.encodedecode: scripts/encodedecodetest.sh $(FLUXENGINE_BIN) $2
+	@mkdir -p $(dir $$@)
+	@echo ENCODEDECODETEST .scp $1 $3
+	@scripts/encodedecodetest.sh $1 scp $(FLUXENGINE_BIN) $2 $3 > $$@
 
 endef
 

--- a/lib/fluxsink/scpfluxsink.cc
+++ b/lib/fluxsink/scpfluxsink.cc
@@ -9,6 +9,7 @@
 #include "proto.h"
 #include "fmt/format.h"
 #include "fluxmap.h"
+#include "layout.h"
 #include "scp.h"
 #include <fstream>
 #include <sys/stat.h>
@@ -16,7 +17,7 @@
 
 static int strackno(int track, int side)
 {
-	return (track << 1) | side;
+    return (track << 1) | side;
 }
 
 static void write_le32(uint8_t dest[4], uint32_t v)
@@ -29,150 +30,170 @@ static void write_le32(uint8_t dest[4], uint32_t v)
 
 static void appendChecksum(uint32_t& checksum, const Bytes& bytes)
 {
-	ByteReader br(bytes);
-	while (!br.eof())
-		checksum += br.read_8();
+    ByteReader br(bytes);
+    while (!br.eof())
+        checksum += br.read_8();
 }
 
 class ScpFluxSink : public FluxSink
 {
 public:
-	ScpFluxSink(const ScpFluxSinkProto& lconfig):
-		_config(lconfig)
-	{
-		bool singlesided = config.heads().start() == config.heads().end();
+    ScpFluxSink(const ScpFluxSinkProto& lconfig): _config(lconfig)
+    {
+        int minTrack;
+        int maxTrack;
+        int minSide;
+        int maxSide;
+        Layout::getBounds(
+            Layout::computeLocations(), minTrack, maxTrack, minSide, maxSide);
 
-		_fileheader.file_id[0] = 'S';
-		_fileheader.file_id[1] = 'C';
-		_fileheader.file_id[2] = 'P';
-		_fileheader.version = 0x18; /* Version 1.8 of the spec */
-		_fileheader.type = _config.type_byte();
-		_fileheader.start_track = strackno(config.tracks().start(), config.heads().start());
-		_fileheader.end_track = strackno(config.tracks().end(), config.heads().end());
-		_fileheader.flags = SCP_FLAG_INDEXED
-				| SCP_FLAG_96TPI;
-		_fileheader.cell_width = 0;
-		_fileheader.heads = singlesided;
+        _fileheader.file_id[0] = 'S';
+        _fileheader.file_id[1] = 'C';
+        _fileheader.file_id[2] = 'P';
+        _fileheader.version = 0x18; /* Version 1.8 of the spec */
+        _fileheader.type = _config.type_byte();
+        _fileheader.start_track = strackno(minTrack, minSide);
+        _fileheader.end_track = strackno(maxTrack, maxSide);
+        _fileheader.flags = SCP_FLAG_INDEXED;
+        if (config.tpi() == 96)
+            _fileheader.flags |= SCP_FLAG_96TPI;
+        _fileheader.cell_width = 0;
+		if ((minSide == 0) && (maxSide == 0))
+			_fileheader.heads = 1;
+		else if ((minSide == 1) && (maxSide == 1))
+			_fileheader.heads = 2;
+		else
+			_fileheader.heads = 0;
 
-		std::cout << fmt::format("SCP: writing 96 tpi {} file containing {} tracks\n",
-			singlesided ? "single sided" : "double sided",
-			_fileheader.end_track - _fileheader.start_track + 1
-		);
+        std::cout << fmt::format(
+            "SCP: writing 96 tpi {} file containing {} tracks\n",
+            (minSide == maxSide) ? "single sided" : "double sided",
+            _fileheader.end_track - _fileheader.start_track + 1);
+    }
 
-	}
+    ~ScpFluxSink()
+    {
+        uint32_t checksum = 0;
+        appendChecksum(checksum,
+            Bytes((const uint8_t*)&_fileheader, sizeof(_fileheader))
+                .slice(0x10));
+        appendChecksum(checksum, _trackdata);
+        write_le32(_fileheader.checksum, checksum);
 
-	~ScpFluxSink()
-	{
-		uint32_t checksum = 0;
-		appendChecksum(checksum,
-			Bytes((const uint8_t*) &_fileheader, sizeof(_fileheader))
-				.slice(0x10));
-		appendChecksum(checksum, _trackdata);
-		write_le32(_fileheader.checksum, checksum);
-
-		std::cout << "SCP: writing output file...\n";
-		std::ofstream of(_config.filename(), std::ios::out | std::ios::binary);
-		if (!of.is_open())
-			Error() << "cannot open output file";
-		of.write((const char*) &_fileheader, sizeof(_fileheader));
-		_trackdata.writeTo(of);
-		of.close();
-	}
+        std::cout << "SCP: writing output file...\n";
+        std::ofstream of(_config.filename(), std::ios::out | std::ios::binary);
+        if (!of.is_open())
+            Error() << "cannot open output file";
+        of.write((const char*)&_fileheader, sizeof(_fileheader));
+        _trackdata.writeTo(of);
+        of.close();
+    }
 
 public:
-	void writeFlux(int track, int head, const Fluxmap& fluxmap) override
-	{
-		ByteWriter trackdataWriter(_trackdata);
-		trackdataWriter.seekToEnd();
-		int strack = strackno(track, head);
+    void writeFlux(int track, int head, const Fluxmap& fluxmap) override
+    {
+        ByteWriter trackdataWriter(_trackdata);
+        trackdataWriter.seekToEnd();
+        int strack = strackno(track, head);
 
-                if (strack >= std::size(_fileheader.track)) {
-                    std::cout << fmt::format("SCP: cannot write track {} head {}, "
-                            "there are not not enough Track Data Headers.\n",
-                            track, head);
-                    return;
+        if (strack >= std::size(_fileheader.track))
+        {
+            std::cout << fmt::format(
+                "SCP: cannot write track {} head {}, "
+                "there are not not enough Track Data Headers.\n",
+                track,
+                head);
+            return;
+        }
+        ScpTrack trackheader = {0};
+        trackheader.header.track_id[0] = 'T';
+        trackheader.header.track_id[1] = 'R';
+        trackheader.header.track_id[2] = 'K';
+        trackheader.header.strack = strack;
+
+        FluxmapReader fmr(fluxmap);
+        Bytes fluxdata;
+        ByteWriter fluxdataWriter(fluxdata);
+
+        int revolution =
+            -1; // -1 indicates that we are before the first index pulse
+        if (_config.align_with_index())
+        {
+            fmr.skipToEvent(F_BIT_INDEX);
+            revolution = 0;
+        }
+        unsigned revTicks = 0;
+        unsigned totalTicks = 0;
+        unsigned ticksSinceLastPulse = 0;
+        uint32_t startOffset = 0;
+        while (revolution < 5)
+        {
+            unsigned ticks;
+            int event;
+            fmr.getNextEvent(event, ticks);
+
+            ticksSinceLastPulse += ticks;
+            totalTicks += ticks;
+            revTicks += ticks;
+
+            // if we haven't output any revolutions yet by the end of the track,
+            // assume that the whole track is one rev
+            // also discard any duplicate index pulses
+            if (((fmr.eof() && revolution <= 0) ||
+                    ((event & F_BIT_INDEX)) && revTicks > 0))
+            {
+                if (fmr.eof() && revolution == -1)
+                    revolution = 0;
+                if (revolution >= 0)
+                {
+                    auto* revheader = &trackheader.revolution[revolution];
+                    write_le32(
+                        revheader->offset, startOffset + sizeof(ScpTrack));
+                    write_le32(revheader->length,
+                        (fluxdataWriter.pos - startOffset) / 2);
+                    write_le32(revheader->index, revTicks * NS_PER_TICK / 25);
+                    revheader++;
                 }
-		ScpTrack trackheader = {0};
-		trackheader.header.track_id[0] = 'T';
-		trackheader.header.track_id[1] = 'R';
-		trackheader.header.track_id[2] = 'K';
-		trackheader.header.strack = strack;
+                revolution++;
+                revTicks = 0;
+                startOffset = fluxdataWriter.pos;
+            }
+            if (fmr.eof())
+                break;
 
-		FluxmapReader fmr(fluxmap);
-		Bytes fluxdata;
-		ByteWriter fluxdataWriter(fluxdata);
+            if (event & F_BIT_PULSE)
+            {
+                unsigned t = ticksSinceLastPulse * NS_PER_TICK / 25;
+                while (t >= 0x10000)
+                {
+                    fluxdataWriter.write_be16(0);
+                    t -= 0x10000;
+                }
+                fluxdataWriter.write_be16(t);
+                ticksSinceLastPulse = 0;
+            }
+        }
 
-		int revolution = -1; // -1 indicates that we are before the first index pulse
-		if (_config.align_with_index()) {
-			fmr.skipToEvent(F_BIT_INDEX);
-			revolution = 0;
-		}
-		unsigned revTicks = 0;
-		unsigned totalTicks = 0;
-		unsigned ticksSinceLastPulse = 0;
-		uint32_t startOffset = 0;
-		while (revolution < 5)
-		{
-			unsigned ticks;
-			int event;
-			fmr.getNextEvent(event, ticks);
+        _fileheader.revolutions = revolution;
+        write_le32(
+            _fileheader.track[strack], trackdataWriter.pos + sizeof(ScpHeader));
+        trackdataWriter += Bytes((uint8_t*)&trackheader, sizeof(trackheader));
+        trackdataWriter += fluxdata;
+    }
 
-			ticksSinceLastPulse += ticks;
-			totalTicks += ticks;
-			revTicks += ticks;
-
-			// if we haven't output any revolutions yet by the end of the track,
-			// assume that the whole track is one rev
-			// also discard any duplicate index pulses
-			if (((fmr.eof() && revolution <= 0) || ((event & F_BIT_INDEX)) && revTicks > 0))
-			{
-				if (fmr.eof() && revolution == -1)
-					revolution = 0;
-				if (revolution >= 0) {
-					auto* revheader = &trackheader.revolution[revolution];
-					write_le32(revheader->offset, startOffset + sizeof(ScpTrack));
-					write_le32(revheader->length, (fluxdataWriter.pos - startOffset) / 2);
-					write_le32(revheader->index, revTicks * NS_PER_TICK / 25);
-					revheader++;
-				}
-				revolution++;
-				revTicks = 0;
-				startOffset = fluxdataWriter.pos;
-			}
-			if (fmr.eof()) break;
-
-			if (event & F_BIT_PULSE)
-			{
-				unsigned t = ticksSinceLastPulse * NS_PER_TICK / 25;
-				while (t >= 0x10000)
-				{
-					fluxdataWriter.write_be16(0);
-					t -= 0x10000;
-				}
-				fluxdataWriter.write_be16(t);
-				ticksSinceLastPulse = 0;
-			}
-		}
-
-		_fileheader.revolutions = revolution;
-		write_le32(_fileheader.track[strack], trackdataWriter.pos + sizeof(ScpHeader));
-		trackdataWriter += Bytes((uint8_t*)&trackheader, sizeof(trackheader));
-		trackdataWriter += fluxdata;
-	}
-
-	operator std::string () const
-	{
-		return fmt::format("scp({})", _config.filename());
-	}
+    operator std::string() const
+    {
+        return fmt::format("scp({})", _config.filename());
+    }
 
 private:
-	const ScpFluxSinkProto& _config;
-	ScpHeader _fileheader = {0};
-	Bytes _trackdata;
+    const ScpFluxSinkProto& _config;
+    ScpHeader _fileheader = {0};
+    Bytes _trackdata;
 };
 
-std::unique_ptr<FluxSink> FluxSink::createScpFluxSink(const ScpFluxSinkProto& config)
+std::unique_ptr<FluxSink> FluxSink::createScpFluxSink(
+    const ScpFluxSinkProto& config)
 {
     return std::unique_ptr<FluxSink>(new ScpFluxSink(config));
 }
-

--- a/lib/layout.cc
+++ b/lib/layout.cc
@@ -58,6 +58,21 @@ std::vector<std::shared_ptr<const TrackInfo>> Layout::computeLocations()
     return locations;
 }
 
+void Layout::getBounds(const std::vector<std::shared_ptr<const TrackInfo>>& locations,
+		int& minTrack, int& maxTrack, int& minSide, int& maxSide)
+{
+	minTrack = minSide = INT_MAX;
+	maxTrack = maxSide = INT_MIN;
+
+	for (auto& ti : locations)
+	{
+		minTrack = std::min<int>(minTrack, ti->physicalTrack);
+		maxTrack = std::max<int>(maxTrack, ti->physicalTrack);
+		minSide = std::min<int>(minSide, ti->physicalSide);
+		maxSide = std::max<int>(maxSide, ti->physicalSide);
+	}
+}
+
 std::vector<std::pair<int, int>> Layout::getTrackOrdering(
     unsigned guessedTracks, unsigned guessedSides)
 {

--- a/lib/layout.h
+++ b/lib/layout.h
@@ -23,9 +23,14 @@ public:
     static unsigned remapSideLogicalToPhysical(unsigned logicalSide);
 
     /* Uses the layout and current track and heads settings to determine
-     * which Locations are going to be read from or written to. 8/
+     * which Locations are going to be read from or written to.
      */
     static std::vector<std::shared_ptr<const TrackInfo>> computeLocations();
+
+	/* Given a list of locations, determines the minimum and maximum track
+	 * and side settings. */
+	static void getBounds(const std::vector<std::shared_ptr<const TrackInfo>>& locations,
+		int& minTrack, int& maxTrack, int& minSide, int& maxSide);
 
     /* Returns a series of <track, side> pairs representing the filesystem
      * ordering of the disk, in logical numbers. */


### PR DESCRIPTION
A few places, including the SCP flux sink, were using the old range config fields rather than the new locations code, resulting in incorrect SCP headers.

Fixes: #593 