### PR TITLE
Library fallback path fixed & MacPorts compatible

### DIFF
--- a/extras/FluxEngine.app.template/Contents/MacOS/FluxEngine.sh
+++ b/extras/FluxEngine.app.template/Contents/MacOS/FluxEngine.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 dir=`dirname "$0"`
 cd "$dir"
-export DYLD_FALLBACK_FRAMEWORK_PATH=../Resources
+export DYLD_FALLBACK_LIBRARY_PATH=../Resources:/opt/local/lib
 exec ./fluxengine-gui "$@"
-


### PR DESCRIPTION
Use correct fallback variable for libs, not for frameworks. Also look for libs in MacPorts' default lib path /opt/local/lib, not only HomeBrew's