### PR TITLE
Fix some nasty Brother bugs.

### DIFF
--- a/lib/vfs/brother120fs.cc
+++ b/lib/vfs/brother120fs.cc
@@ -31,7 +31,18 @@ public:
     {
         ByteReader br(bytes);
         filename = br.read(8);
-        filename = filename.substr(0, filename.find(' '));
+
+        for (int i = 0; filename.size(); i++)
+        {
+            if (filename[i] == ' ')
+            {
+                filename = filename.substr(0, i);
+                break;
+            }
+            if ((filename[i] < 32) || (filename[i] > 126))
+                throw BadFilesystemException();
+        }
+
         path = {filename};
 
         brotherType = br.read_8();
@@ -91,7 +102,7 @@ public:
             for (int d = 0; d < SECTOR_SIZE / 16; d++)
             {
                 Bytes buffer = bytes.slice(d * 16, 16);
-                if (buffer[0] == 0xf0)
+                if (buffer[0] & 0x80)
                     continue;
 
                 auto de = std::make_shared<Brother120Dirent>(buffer);

--- a/src/formats/brother120.textpb
+++ b/src/formats/brother120.textpb
@@ -18,7 +18,7 @@ layout {
 		physical {
 			start_sector: 0
 			count: 12
-			skew: 5
+			#skew: 5
 		}
 	}
 }

--- a/src/formats/brother240.textpb
+++ b/src/formats/brother240.textpb
@@ -18,7 +18,7 @@ layout {
 		physical {
 			start_sector: 0
 			count: 12
-			skew: 5
+			#skew: 5
 		}
 	}
 }
@@ -32,7 +32,7 @@ decoder {
 }
 
 drive {
-	head_bias: 1
+	head_bias: 3
 }
 
 filesystem {


### PR DESCRIPTION
- images were read and written hopelessly wrong (due to bad sector skew)
- brother120 filesystems were poorly detected (not at all detected) and could cause crashes if you tried to use one on something which wasn't a brother120 filesystem.