### PR TITLE
When overriding the layout, make sure that the previous layout is erased.

### DIFF
--- a/lib/imagereader/d88imagereader.cc
+++ b/lib/imagereader/d88imagereader.cc
@@ -77,6 +77,7 @@ public:
                 config.set_tpi(48);
         }
 
+		config.clear_layout();
 		auto layout = config.mutable_layout();
         std::unique_ptr<Image> image(new Image);
         for (int track = 0; track < trackTableSize / 4; track++)

--- a/src/gui/imagerpanel.cc
+++ b/src/gui/imagerpanel.cc
@@ -74,7 +74,6 @@ private:
 
     void OnQueueFailed() override
     {
-        fmt::print("queue failed\n");
         if (_state == STATE_READING_WORKING)
             _state = STATE_READING_FAILED;
         else if (_state == STATE_WRITING_WORKING)

--- a/src/gui/main.cc
+++ b/src/gui/main.cc
@@ -75,6 +75,11 @@ wxThread::ExitCode FluxEngineApp::Entry()
     {
         Logger() << EmergencyStopMessage();
     }
+	catch (const std::exception& e)
+	{
+		Logger() << ErrorLogMessage{
+		fmt::format("unhandled exception: {}\n", e.what())};
+	}
 
     postToUiThread(
         [&]


### PR DESCRIPTION
Fixes: #655 