### PR TITLE
Rename the `requires` config field to `prerequisite`

### DIFF
--- a/arch/c64/encoder.cc
+++ b/arch/c64/encoder.cc
@@ -51,26 +51,6 @@ static void write_bits(
     }
 }
 
-void bindump(std::ostream& stream, std::vector<bool>& buffer)
-{
-    size_t pos = 0;
-
-    while ((pos < buffer.size()) and (pos < 520))
-    {
-        stream << fmt::format("{:5d} : ", pos);
-        for (int i = 0; i < 40; i++)
-        {
-            if ((pos + i) < buffer.size())
-                stream << fmt::format("{:01b}", (buffer[pos + i]));
-            else
-                stream << "-- ";
-            if ((((pos + i + 1) % 8) == 0) and i != 0)
-                stream << "  ";
-        }
-        stream << std::endl;
-        pos += 40;
-    }
-}
 static std::vector<bool> encode_data(uint8_t input)
 {
     /*

--- a/lib/config.cc
+++ b/lib/config.cc
@@ -29,7 +29,7 @@ ConfigProto* Config::combined()
         /* First apply any standalone options. */
 
         std::set<std::string> options = _appliedOptions;
-        std::set<const OptionRequirementProto*> requirements;
+        std::set<const OptionPrerequisiteProto*> prereqs;
         for (const auto& option : _baseConfig.option())
         {
             if (options.find(option.name()) != options.end())
@@ -257,7 +257,7 @@ const OptionProto& Config::findOption(const std::string& optionName)
 
 void Config::checkOptionValid(const OptionProto& option)
 {
-    for (const auto& req : option.requires())
+    for (const auto& req : option.prerequisite())
     {
         bool matched = false;
         try

--- a/lib/config.proto
+++ b/lib/config.proto
@@ -50,7 +50,7 @@ message ConfigProto
     repeated OptionGroupProto option_group = 20;
 }
 
-message OptionRequirementProto
+message OptionPrerequisiteProto
 {
     optional string key = 1 [ (help) = "path to config value" ];
     repeated string value = 2 [ (help) = "list of required values" ];
@@ -65,7 +65,7 @@ message OptionProto
         [ (help) = "message to display when option is in use" ];
     optional bool set_by_default = 6
         [ (help) = "this option is applied by default", default = false ];
-    repeated OptionRequirementProto requires = 7
+    repeated OptionPrerequisiteProto prerequisite = 7
         [ (help) = "prerequisites for this option" ];
 
     optional ConfigProto config = 4

--- a/lib/fl2.cc
+++ b/lib/fl2.cc
@@ -30,8 +30,8 @@ static void upgradeFluxFile(FluxFileProto& proto)
         error(
             "this is a version {} flux file, but this build of the client can "
             "only handle up to version {} --- please upgrade",
-            proto.version(),
-            FluxFileVersion::VERSION_2);
+            (int)proto.version(),
+            (int)FluxFileVersion::VERSION_2);
 }
 
 FluxFileProto loadFl2File(const std::string filename)

--- a/lib/fluxsink/scpfluxsink.cc
+++ b/lib/fluxsink/scpfluxsink.cc
@@ -180,7 +180,7 @@ public:
         trackdataWriter += fluxdata;
     }
 
-    operator std::string() const
+    operator std::string() const override
     {
         return fmt::format("scp({})", _config.filename());
     }

--- a/lib/fluxsink/vcdfluxsink.cc
+++ b/lib/fluxsink/vcdfluxsink.cc
@@ -64,7 +64,7 @@ public:
         of << "\n";
     }
 
-    operator std::string() const
+    operator std::string() const override
     {
         return fmt::format("vcd({})", _config.directory());
     }

--- a/lib/fluxsource/a2rfluxsource.cc
+++ b/lib/fluxsource/a2rfluxsource.cc
@@ -142,7 +142,7 @@ public:
         }
     }
 
-    void recalibrate() {}
+    void recalibrate() override {}
 
 private:
     Bytes findChunk(Bytes id)

--- a/lib/fluxsource/erasefluxsource.cc
+++ b/lib/fluxsource/erasefluxsource.cc
@@ -15,7 +15,7 @@ public:
         return std::unique_ptr<const Fluxmap>();
     }
 
-    void recalibrate() {}
+    void recalibrate() override {}
 };
 
 std::unique_ptr<FluxSource> FluxSource::createEraseFluxSource(

--- a/lib/fluxsource/fl2fluxsource.cc
+++ b/lib/fluxsource/fl2fluxsource.cc
@@ -39,8 +39,8 @@ public:
 
         _extraConfig.mutable_drive()->set_rotational_period_ms(
             _proto.rotational_period_ms());
-		if (_proto.has_tpi())
-			_extraConfig.mutable_drive()->set_tpi(_proto.tpi());
+        if (_proto.has_tpi())
+            _extraConfig.mutable_drive()->set_tpi(_proto.tpi());
     }
 
 public:
@@ -55,7 +55,7 @@ public:
         return std::make_unique<EmptyFluxSourceIterator>();
     }
 
-    void recalibrate() {}
+    void recalibrate() override {}
 
 private:
     void check_for_error(std::ifstream& ifs)

--- a/lib/fluxsource/flxfluxsource.cc
+++ b/lib/fluxsource/flxfluxsource.cc
@@ -19,7 +19,7 @@ public:
         return readFlxBytes(Bytes::readFromFile(path));
     }
 
-    void recalibrate() {}
+    void recalibrate() override {}
 
 private:
     const std::string _path;

--- a/lib/fluxsource/scpfluxsource.cc
+++ b/lib/fluxsource/scpfluxsource.cc
@@ -128,7 +128,7 @@ public:
         return fluxmap;
     }
 
-    void recalibrate() {}
+    void recalibrate() override {}
 
 private:
     void check_for_error()

--- a/lib/imagewriter/imdimagewriter.cc
+++ b/lib/imagewriter/imdimagewriter.cc
@@ -273,6 +273,8 @@ public:
                             case ImdOutputProto::RATE_DD:
                                 RATE = 2000;
                                 break;
+                            case ImdOutputProto::RATE_GUESS:
+                                break;
                         }
                     }
                     header.ModeValue =

--- a/lib/proto.cc
+++ b/lib/proto.cc
@@ -119,6 +119,7 @@ static ProtoField resolveProtoPath(
         switch (field->label())
         {
             case google::protobuf::FieldDescriptor::LABEL_OPTIONAL:
+            case google::protobuf::FieldDescriptor::LABEL_REQUIRED:
                 if (!create && !reflection->HasField(*message, field))
                     throw ProtoPathNotFoundException(fmt::format(
                         "could not find config field '{}'", field->name()));
@@ -139,7 +140,7 @@ static ProtoField resolveProtoPath(
                 break;
 
             default:
-                error("bad proto label {}", field->label());
+                error("bad proto label for field '{}' in '{}'", item, path);
         }
 
         descriptor = message->GetDescriptor();

--- a/lib/sector.h
+++ b/lib/sector.h
@@ -90,6 +90,16 @@ struct Sector : public LogicalLocation
     }
 };
 
+template <>
+struct fmt::formatter<Sector::Status> : formatter<string_view>
+{
+    auto format(Sector::Status status, format_context& ctx) const
+    {
+        return formatter<string_view>::format(
+            Sector::statusToString(status), ctx);
+    }
+};
+
 extern bool sectorPointerSortPredicate(const std::shared_ptr<const Sector>& lhs,
     const std::shared_ptr<const Sector>& rhs);
 extern bool sectorPointerEqualsPredicate(

--- a/lib/usb/fluxengineusb.cc
+++ b/lib/usb/fluxengineusb.cc
@@ -76,7 +76,7 @@ public:
                 "your FluxEngine firmware is at version {} but the client is "
                 "for version {}; please upgrade",
                 version,
-                FLUXENGINE_PROTOCOL_VERSION);
+                (int) FLUXENGINE_PROTOCOL_VERSION);
     }
 
 private:

--- a/lib/vfs/amigaffs.cc
+++ b/lib/vfs/amigaffs.cc
@@ -56,7 +56,7 @@ public:
     {
     }
 
-    uint32_t capabilities() const
+    uint32_t capabilities() const override
     {
         return OP_GETFSDATA | OP_CREATE | OP_LIST | OP_GETFILE | OP_PUTFILE |
                OP_GETDIRENT | OP_DELETE | OP_MOVE | OP_CREATEDIR;
@@ -229,7 +229,7 @@ public:
             throw CannotWriteException();
     }
 
-    void createDirectory(const Path& path)
+    void createDirectory(const Path& path) override
     {
         AdfMount m(this);
         if (path.empty())

--- a/lib/vfs/appledos.cc
+++ b/lib/vfs/appledos.cc
@@ -50,7 +50,7 @@ public:
     {
     }
 
-    uint32_t capabilities() const
+    uint32_t capabilities() const override
     {
         return OP_LIST | OP_GETDIRENT | OP_GETFSDATA | OP_GETFILE;
     }

--- a/lib/vfs/brother120fs.cc
+++ b/lib/vfs/brother120fs.cc
@@ -232,7 +232,7 @@ public:
     {
     }
 
-    uint32_t capabilities() const
+    uint32_t capabilities() const override
     {
         return OP_GETFSDATA | OP_LIST | OP_GETFILE | OP_PUTFILE | OP_GETDIRENT |
                OP_DELETE;

--- a/lib/vfs/cbmfs.cc
+++ b/lib/vfs/cbmfs.cc
@@ -195,7 +195,7 @@ public:
     {
     }
 
-    uint32_t capabilities() const
+    uint32_t capabilities() const override
     {
         return OP_GETFSDATA | OP_LIST | OP_GETFILE | OP_GETDIRENT;
     }

--- a/lib/vfs/cpmfs.cc
+++ b/lib/vfs/cpmfs.cc
@@ -81,7 +81,7 @@ public:
     {
     }
 
-    uint32_t capabilities() const
+    uint32_t capabilities() const override
     {
         return OP_GETFSDATA | OP_LIST | OP_GETFILE | OP_GETDIRENT;
     }

--- a/lib/vfs/fatfs.cc
+++ b/lib/vfs/fatfs.cc
@@ -296,7 +296,7 @@ private:
 
             default:
                 throw FilesystemException(
-                    fmt::format("unknown fatfs error {}", res));
+                    fmt::format("unknown fatfs error {}", (int) res));
         }
     }
 

--- a/lib/vfs/fatfs.cc
+++ b/lib/vfs/fatfs.cc
@@ -36,7 +36,7 @@ public:
     {
     }
 
-    uint32_t capabilities() const
+    uint32_t capabilities() const override
     {
         return OP_GETFSDATA | OP_CREATE | OP_LIST | OP_GETFILE | OP_PUTFILE |
                OP_GETDIRENT | OP_MOVE | OP_CREATEDIR | OP_DELETE;
@@ -199,7 +199,7 @@ public:
         throwError(res);
     }
 
-    void createDirectory(const Path& path)
+    void createDirectory(const Path& path) override
     {
         mount();
         auto pathStr = path.to_str();
@@ -296,7 +296,7 @@ private:
 
             default:
                 throw FilesystemException(
-                    fmt::format("unknown fatfs error {}", (int) res));
+                    fmt::format("unknown fatfs error {}", (int)res));
         }
     }
 

--- a/lib/vfs/fluxsectorinterface.cc
+++ b/lib/vfs/fluxsectorinterface.cc
@@ -44,7 +44,7 @@ public:
         return _changedSectors.put(track, side, sectorId);
     }
 
-    virtual bool isReadOnly()
+    virtual bool isReadOnly() override
     {
         return (_fluxSink == nullptr);
     }

--- a/lib/vfs/imagesectorinterface.cc
+++ b/lib/vfs/imagesectorinterface.cc
@@ -20,19 +20,19 @@ public:
 
 public:
     std::shared_ptr<const Sector> get(
-        unsigned track, unsigned side, unsigned sectorId)
+        unsigned track, unsigned side, unsigned sectorId) override
     {
         return _image->get(track, side, sectorId);
     }
 
     std::shared_ptr<Sector> put(
-        unsigned track, unsigned side, unsigned sectorId)
+        unsigned track, unsigned side, unsigned sectorId) override
     {
         _changed = true;
         return _image->put(track, side, sectorId);
     }
 
-    virtual bool isReadOnly()
+    virtual bool isReadOnly() override
     {
         return (_writer == nullptr);
     }

--- a/lib/vfs/machfs.cc
+++ b/lib/vfs/machfs.cc
@@ -23,7 +23,7 @@ public:
     {
     }
 
-    uint32_t capabilities() const
+    uint32_t capabilities() const override
     {
         return OP_GETFSDATA | OP_CREATE | OP_LIST | OP_GETFILE | OP_PUTFILE |
                OP_GETDIRENT | OP_MOVE | OP_CREATEDIR | OP_DELETE;

--- a/lib/vfs/philefs.cc
+++ b/lib/vfs/philefs.cc
@@ -160,7 +160,7 @@ public:
     {
     }
 
-    uint32_t capabilities() const
+    uint32_t capabilities() const override
     {
         return OP_GETFSDATA | OP_LIST | OP_GETFILE | OP_GETDIRENT;
     }

--- a/lib/vfs/prodos.cc
+++ b/lib/vfs/prodos.cc
@@ -140,7 +140,7 @@ public:
     {
     }
 
-    uint32_t capabilities() const
+    uint32_t capabilities() const override
     {
         return OP_LIST | OP_GETDIRENT | OP_GETFILE | OP_GETFSDATA;
     }

--- a/lib/vfs/sectorinterface.h
+++ b/lib/vfs/sectorinterface.h
@@ -12,6 +12,9 @@ class Encoder;
 class SectorInterface
 {
 public:
+	virtual ~SectorInterface() {}
+
+public:
     virtual std::shared_ptr<const Sector> get(
         unsigned track, unsigned side, unsigned sectorId) = 0;
     virtual std::shared_ptr<Sector> put(

--- a/lib/vfs/smaky6fs.cc
+++ b/lib/vfs/smaky6fs.cc
@@ -139,7 +139,7 @@ public:
     {
     }
 
-    uint32_t capabilities() const
+    uint32_t capabilities() const override
     {
         return OP_LIST | OP_GETFILE | OP_GETFSDATA | OP_GETDIRENT;
     }

--- a/scripts/mkdocindex.cc
+++ b/scripts/mkdocindex.cc
@@ -14,9 +14,10 @@ static std::string supportStatus(SupportStatus status)
 
         case SupportStatus::UNICORN:
             return "🦄";
-    }
 
-    return "";
+        case SupportStatus::UNSUPPORTED:
+            return "";
+    }
 }
 
 int main(int argc, const char* argv[])

--- a/src/gui/build.mk
+++ b/src/gui/build.mk
@@ -68,20 +68,20 @@ FluxEngine.pkg: FluxEngine.app
 	@echo PKGBUILD $@
 	@pkgbuild --quiet --install-location /Applications --component $< $@
 
-FluxEngine.app: fluxengine-gui$(EXT) $(OBJDIR)/fluxengine.icns
+FluxEngine.app: fluxengine-gui$(EXT) $(OBJDIR)/fluxengine.icns src/gui/build.mk
 	@echo MAKEAPP $@
-	@rm -rf $@
-	@cp -a extras/FluxEngine.app.template $@
-	@touch $@
-	@cp fluxengine-gui$(EXT) $@/Contents/MacOS/fluxengine-gui
-	@mkdir -p $@/Contents/Resources
-	@cp $(OBJDIR)/fluxengine.icns $@/Contents/Resources/FluxEngine.icns
-	@dylibbundler -of -x $@/Contents/MacOS/fluxengine-gui -b -d $@/Contents/libs -cd > /dev/null
-	@cp /usr/local/opt/wxwidgets/README.md $@/Contents/libs/wxWidgets.md
-	@cp /usr/local/opt/protobuf/LICENSE $@/Contents/libs/protobuf.txt
-	@cp /usr/local/opt/fmt/LICENSE.rst $@/Contents/libs/fmt.rst
-	@cp /usr/local/opt/libpng/LICENSE $@/Contents/libs/libpng.txt
-	@cp /usr/local/opt/libjpeg/README $@/Contents/libs/libjpeg.txt
+	rm -rf $@
+	cp -a extras/FluxEngine.app.template $@
+	touch $@
+	cp fluxengine-gui$(EXT) $@/Contents/MacOS/fluxengine-gui
+	mkdir -p $@/Contents/Resources
+	cp $(OBJDIR)/fluxengine.icns $@/Contents/Resources/FluxEngine.icns
+	dylibbundler -of -x $@/Contents/MacOS/fluxengine-gui -b -d $@/Contents/libs -cd > /dev/null
+	cp $$(brew --prefix wxwidgets)/README.md $@/Contents/libs/wxWidgets.md
+	cp $$(brew --prefix protobuf)/LICENSE $@/Contents/libs/protobuf.txt
+	cp $$(brew --prefix fmt)/LICENSE.rst $@/Contents/libs/fmt.rst
+	cp $$(brew --prefix libpng)/LICENSE $@/Contents/libs/libpng.txt
+	cp $$(brew --prefix libjpeg)/README $@/Contents/libs/libjpeg.txt
 
 $(OBJDIR)/fluxengine.icns: $(OBJDIR)/fluxengine.iconset
 	@echo ICONUTIL $@

--- a/src/gui/imagerpanel.cc
+++ b/src/gui/imagerpanel.cc
@@ -78,7 +78,7 @@ private:
     }
 
 public:
-    void StartReading()
+    void StartReading() override
     {
         try
         {

--- a/src/gui/mainwindow.cc
+++ b/src/gui/mainwindow.cc
@@ -83,7 +83,7 @@ public:
         Fit();
     }
 
-    void SafeFit()
+    void SafeFit() override
     {
         auto minSize = GetMinClientSize();
 
@@ -94,32 +94,32 @@ public:
         SetMinClientSize(minSize);
     }
 
-    void StartIdle()
+    void StartIdle() override
     {
         _idlePanel->Start();
     }
 
-    void StartReading()
+    void StartReading() override
     {
         _imagerPanel->StartReading();
     }
 
-    void StartWriting()
+    void StartWriting() override
     {
         _imagerPanel->StartWriting();
     }
 
-    void StartBrowsing()
+    void StartBrowsing() override
     {
         _browserPanel->StartBrowsing();
     }
 
-    void StartFormatting()
+    void StartFormatting() override
     {
         _browserPanel->StartFormatting();
     }
 
-    void StartExploring()
+    void StartExploring() override
     {
         _explorerPanel->Start();
     }
@@ -186,7 +186,7 @@ public:
         _configWindow->GetTextControl()->AppendText(s);
     }
 
-    void PrepareConfig()
+    void PrepareConfig() override
     {
         _idlePanel->PrepareConfig();
         ShowConfig();

--- a/tests/options.cc
+++ b/tests/options.cc
@@ -29,7 +29,7 @@ static void test_option_validity()
         option {
             name: "option1"
 
-            requires: {
+            prerequisite: {
                 key: "drive.tpi"
                 value: "96"
             }
@@ -38,7 +38,7 @@ static void test_option_validity()
         option {
             name: "option2"
 
-            requires: {
+            prerequisite: {
                 key: "drive.tpi"
                 value: "95"
             }
@@ -47,7 +47,7 @@ static void test_option_validity()
         option {
             name: "option3"
 
-            requires: {
+            prerequisite: {
                 key: "drive.tpi"
                 value: ["0", "96"]
             }


### PR DESCRIPTION
`requires` is about to become a C++ keyword.
Also do some related OSX cleanup and fixes.

Fixes: #691 
Fixes: #693 
Fixes: #687 
Ref: #643 