### PR TITLE
Makefile: Eagerly run pkg-config for protobuf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,12 +138,12 @@ PROTOS = \
 PROTO_HDRS = $(patsubst %.proto, $(OBJDIR)/%.pb.h, $(PROTOS))
 PROTO_SRCS = $(patsubst %.proto, $(OBJDIR)/%.pb.cc, $(PROTOS))
 PROTO_OBJS = $(patsubst %.cc, %.o, $(PROTO_SRCS))
-PROTO_CFLAGS = $(shell $(PKG_CONFIG) --cflags protobuf)
+PROTO_CFLAGS := $(shell $(PKG_CONFIG) --cflags protobuf)
 $(PROTO_SRCS): | $(PROTO_HDRS)
 $(PROTO_OBJS): CFLAGS += $(PROTO_CFLAGS)
 PROTO_LIB = $(OBJDIR)/libproto.a
 $(PROTO_LIB): $(PROTO_OBJS)
-PROTO_LDFLAGS = $(shell $(PKG_CONFIG) --libs protobuf) -pthread
+PROTO_LDFLAGS := $(shell $(PKG_CONFIG) --libs protobuf) -pthread
 .PRECIOUS: $(PROTO_HDRS) $(PROTO_SRCS)
 
 include dep/agg/build.mk


### PR DESCRIPTION
Protobuf added a dependency on absl and now pkg-config is incredibly slow. `pkg-config --libs protobuf` and `--cflags` each take around 1.5 seconds on my laptop. Running pkg-config only once reduces a 100% incremental build for 'make all' from 90 seconds to 3.2 seconds.

Unfortunately we will pay the 3 seconds every time we execute make, even for something that doesn't need protobuf.