### PR TITLE
Fix const-correct/discards qualifiers error.

### DIFF
--- a/lib/sector.h
+++ b/lib/sector.h
@@ -93,7 +93,7 @@ struct Sector : public LogicalLocation
 template <>
 struct fmt::formatter<Sector::Status> : formatter<string_view>
 {
-    auto format(Sector::Status status, format_context& ctx) const
+    auto format(Sector::Status status, format_context& ctx)
     {
         return formatter<string_view>::format(
             Sector::statusToString(status), ctx);


### PR DESCRIPTION
This should fix #696 and let gcc compile FluxEngine.