### PR TITLE
Set DTR after calling SetCommState

### DIFF
--- a/lib/usb/serial.cc
+++ b/lib/usb/serial.cc
@@ -97,6 +97,12 @@ public:
             .Parity = NOPARITY,
             .StopBits = ONESTOPBIT};
         SetCommState(_handle, &dcb);
+
+        if (!EscapeCommFunction(_handle, CLRDTR))
+            error("Couldn't clear DTR: {}", get_last_error_string());
+        Sleep(200);
+        if (!EscapeCommFunction(_handle, SETDTR))
+            error("Couldn't set DTR: {}", get_last_error_string());
     }
 
 private:


### PR DESCRIPTION
After calling SetCommState in setBaudRate DTR is no longer set. 
The amendment in this request clears and sets DTR again, like in the constructor.