### PR TITLE
fix broken screenshot link

### DIFF
--- a/doc/using.md
+++ b/doc/using.md
@@ -15,7 +15,7 @@ If possible, try using the GUI, which should provide simplified access for most
 common operations.
 
 <div style="text-align: center">
-<a href="doc/screenshot-details.png"><img src="doc/screenshot-details.png" style="width:60%" alt="screenshot of the GUI in action"></a>
+<a href="/doc/screenshot-details.png"><img src="/doc/screenshot-details.png" style="width:60%" alt="screenshot of the GUI in action"></a>
 </div>
 
 ### Core concepts


### PR DESCRIPTION
Path was relative so it was looking for doc/doc/screenshot-details.png instead of doc/screenshot-details.png, causing a 404.