### PR TITLE
Fix Linux compile issues related to protobuf

### DIFF
--- a/lib/config/proto.cc
+++ b/lib/config/proto.cc
@@ -288,7 +288,7 @@ std::string getProtoFieldValue(ProtoField& protoField)
         case google::protobuf::FieldDescriptor::TYPE_ENUM:
         {
             const auto* enumvalue = reflection->GetEnum(*message, field);
-            return enumvalue->name();
+            return static_cast<std::string>(enumvalue->name());
         }
 
         case google::protobuf::FieldDescriptor::TYPE_MESSAGE:
@@ -355,7 +355,7 @@ findAllProtoFields(google::protobuf::Message* message)
         for (int i = 0; i < d->field_count(); i++)
         {
             const google::protobuf::FieldDescriptor* f = d->field(i);
-            std::string n = s + f->name();
+            std::string n = s + static_cast<std::string>(f->name());
 
             if (f->options().GetExtension(::recurse) &&
                 (f->type() == google::protobuf::FieldDescriptor::TYPE_MESSAGE))

--- a/scripts/mkdocindex.cc
+++ b/scripts/mkdocindex.cc
@@ -43,7 +43,7 @@ int main(int argc, const char* argv[])
             {
                 const auto* descriptor =
                     FilesystemProto::FilesystemType_descriptor();
-                auto name = descriptor->FindValueByNumber(fs.type())->name();
+                auto name = static_cast<std::string>(descriptor->FindValueByNumber(fs.type())->name());
 
                 filesystems.insert(name);
             }


### PR DESCRIPTION
Couldn't compile this on Linux with Protobuf 3.31, seems to be related to issue #804 where string_view could not be implicitly converted to std::string. This fixes the build by making the conversions explicit.