### PR TITLE
Fix histogram formatting

### DIFF
--- a/src/fe-inspect.cc
+++ b/src/fe-inspect.cc
@@ -106,7 +106,7 @@ static nanoseconds_t guessClock(const Fluxmap& fluxmap)
             s += BLOCK_ELEMENTS[bar & 7];
 
             std::cout << fmt::format(
-                "{: 3} {:.2f} {:6} {}", i, (double)i * US_PER_TICK, value, s);
+                "{: 3} {:.2f} {:7} {}", i, (double)i * US_PER_TICK, value, s);
             std::cout << std::endl;
         }
     }
@@ -284,3 +284,4 @@ int mainInspect(int argc, const char* argv[])
 
     return 0;
 }
+


### PR DESCRIPTION
Fix `analyze` histogram formatting which formats to 6 digits. Reading a 5.25" Apple II disk, I'm seeing 7 digits.
```
Clock detection histogram:
 38 3.17 738179 ██████████▌
 39 3.25 2804365 ████████████████████████████████████████
 40 3.33 2134391 ██████████████████████████████▍
 41 3.42 2412047 ██████████████████████████████████▍
 42 3.50 1200997 █████████████████▏
 43 3.58 743494 ██████████▌
 44 3.67  95948 █▎
```