### PR TITLE
Add build documentation for RHEL and Fedora

### DIFF
--- a/doc/building-client.md
+++ b/doc/building-client.md
@@ -15,6 +15,13 @@ install some support packages. **You will need to check out git with submodules 
     `libmagic-dev` `libdbus-1-dev` `libglfw3-dev` `libfreetype-dev`
     `libboost-regex-dev` Plus, optionally (if not present, internal versions
     will be used): `nlohmann-json3-dev` `libcli11-dev` `libmd4c-dev`
+  - For Linux with RHEL+EPEL/Fedora:
+    `@c-development` `git` `ninja-build` `protobuf-compiler`
+    `libudev-devel` `sqlite-devel` `fmt-devel` `protobuf-devel` `file-devel`
+    `mbedtls-devel` `libcurl-devel` `dbus-devel` `glfw-devel` `freetype-devel`
+    `boost-devel` `systemd-devel`
+    Plus, optionally (if not present, internal versions will be used):
+    `cli11-devel` `md4c-devel` `lunasvg-devel`
   - For OSX with Homebrew:
     `sqlite` `pkg-config` `libusb` `protobuf` `fmt` `make` `coreutils`
     `dylibbundler` `libjpeg` `libmagic`  `boost` `glfw3` `ninja` `python`

--- a/doc/building-client.md
+++ b/doc/building-client.md
@@ -12,7 +12,7 @@ install some support packages. **You will need to check out git with submodules 
   - For Linux with Ubuntu/Debian:
     `libudev-dev` `libsqlite3-dev` `protobuf-compiler` `libfmt-dev`
     `libprotobuf-dev` `libmagic-dev` `libmbedtls-dev` `libcurl4-openssl-dev`
-    `libmagic-dev` `libdbus-1-dev` `libglfw3-dev` `libfreetype-dev`
+    `libdbus-1-dev` `libglfw3-dev` `libfreetype-dev`
     `libboost-regex-dev` Plus, optionally (if not present, internal versions
     will be used): `nlohmann-json3-dev` `libcli11-dev` `libmd4c-dev`
   - For Linux with RHEL+EPEL/Fedora:


### PR DESCRIPTION
I added the necessary package list for building fluxengine for RHEL and Fedora.  I'm not sure if there's anywhere else in the docs that also need to be updated to reflect this change.

I also found a redundant package in the Ubuntu package list.  I deleted it in a separate commit.

Feel free to do anything at all you want to the commits.