### PR TITLE
smaky6fs: fix size bug, 0xFF deleted entries, decode directory metadata

### DIFF
--- a/lib/vfs/smaky6fs.cc
+++ b/lib/vfs/smaky6fs.cc
@@ -5,9 +5,19 @@
 
 /* A directory entry looks like:
  *
- * 00-09: ten byte filename FFFFFFFF.EE
- * 0a-0b: word: start sector
- * 0c-17: unknown
+ * 00-07: name, space-padded ASCII (high bit may be set as attribute flag → mask with 0x7f)
+ * 08-09: 2-char type code (SY, SM, ST, SR, LS, FH, BS, IM, KS …)
+ * 0a-0b: uint16 LE start_sector  – first data sector (0-based absolute)
+ * 0c-0d: uint16 LE end_sector    – first sector after the file (exclusive)
+ * 0e-0f: uint16 LE flags         – purpose unknown
+ * 10-11: uint16 LE last_bytes    – bytes used in last sector;
+ *                                   0 means last sector is completely full
+ *         exact_size = (size_sectors-1)*256 + last_bytes  if last_bytes > 0
+ *                      size_sectors * 256                  if last_bytes == 0
+ * 12-13: load address  – high byte then low byte (reliable for type SM)
+ * 14-15: entry point   – same encoding
+ * 16:    month BCD (0x07 = July);  0x00 or 0xFF = no date
+ * 17:    year  BCD (0x82 = 1982);  0x00 or 0xFF = no date
  */
 
 class Smaky6Filesystem : public Filesystem
@@ -57,37 +67,59 @@ class Smaky6Filesystem : public Filesystem
                 filename = ss.str();
             }
 
-            std::string metadataBytes;
-            {
-                std::stringstream ss;
-
-                for (int i = 10; i < 0x18; i++)
-                    ss << fmt::format("{:02x} ", (uint8_t)dbuf[i]);
-
-                metadataBytes = ss.str();
-            }
-
             ByteReader br(dbuf);
-
-            br.skip(10); /* filename */
+            br.skip(10); /* skip filename/type already parsed above */
             startSector = br.read_le16();
-            endSector = br.read_le16();
-            br.skip(2); /* unknown */
+            endSector   = br.read_le16();
+            uint16_t flags = br.read_le16(); /* purpose unknown */
             lastSectorLength = br.read_le16();
+            uint8_t loadHi  = br.read_8();
+            uint8_t loadLo  = br.read_8();
+            uint8_t entryHi = br.read_8();
+            uint8_t entryLo = br.read_8();
+            uint8_t monthBcd = br.read_8();
+            uint8_t yearBcd  = br.read_8();
+
+            /* Decode BCD date; 0x00 and 0xFF both mean "no date" */
+            auto bcdToInt = [](uint8_t b) -> int {
+                return (b >> 4) * 10 + (b & 0x0f);
+            };
+            int month = (monthBcd && monthBcd != 0xff) ? bcdToInt(monthBcd) : 0;
+            int year  = (yearBcd  && yearBcd  != 0xff) ? bcdToInt(yearBcd)  : 0;
+
+            uint16_t loadAddr  = ((uint16_t)loadHi  << 8) | loadLo;
+            uint16_t entryAddr = ((uint16_t)entryHi << 8) | entryLo;
 
             file_type = TYPE_FILE;
-            length = (endSector - startSector - 1) * 256 + lastSectorLength;
+            /* When lastSectorLength == 0 the last sector is completely full;
+             * FluxEngine's original formula subtracted 256 bytes in that case. */
+            length = lastSectorLength
+                ? (endSector - startSector - 1) * 256 + lastSectorLength
+                : (endSector - startSector) * 256;
 
             path = {filename};
             attributes[Filesystem::FILENAME] = filename;
-            attributes[Filesystem::LENGTH] = std::to_string(length);
+            attributes[Filesystem::LENGTH]    = std::to_string(length);
             attributes[Filesystem::FILE_TYPE] = "file";
-            attributes[Filesystem::MODE] = "";
+            attributes[Filesystem::MODE]      = "";
             attributes["smaky6.start_sector"] = std::to_string(startSector);
-            attributes["smaky6.end_sector"] = std::to_string(endSector);
-            attributes["smaky6.sectors"] =
-                std::to_string(endSector - startSector);
-            attributes["smaky6.metadata_bytes"] = metadataBytes;
+            attributes["smaky6.end_sector"]   = std::to_string(endSector);
+            attributes["smaky6.sectors"]      = std::to_string(endSector - startSector);
+            attributes["smaky6.flags"]        = fmt::format("0x{:04x}", flags);
+            if (loadAddr)
+                attributes["smaky6.load_addr"]  = fmt::format("0x{:04x}", loadAddr);
+            if (entryAddr)
+                attributes["smaky6.entry_addr"] = fmt::format("0x{:04x}", entryAddr);
+            if (month && year)
+            {
+                static const char* months[] = {"","Jan","Feb","Mar","Apr","May","Jun",
+                                                "Jul","Aug","Sep","Oct","Nov","Dec"};
+                int yearFull = (year >= 78) ? 1900 + year : 2000 + year;
+                attributes["smaky6.date"] =
+                    fmt::format("{} {}",
+                        (month >= 1 && month <= 12) ? months[month] : "?",
+                        yearFull);
+            }
         }
 
     public:
@@ -110,7 +142,8 @@ class Smaky6Filesystem : public Filesystem
             for (int i = 0; i < 32; i++)
             {
                 auto dbuf = bytes.slice(i * 0x18, 0x18);
-                if (dbuf[0])
+                /* 0x00 = empty slot; 0xFF = deleted entry (used by system files) */
+                if (dbuf[0] && dbuf[0] != 0xff)
                 {
                     auto de = std::make_shared<SmakyDirent>(dbuf);
                     dirents.push_back(de);

--- a/lib/vfs/smaky6fs.cc
+++ b/lib/vfs/smaky6fs.cc
@@ -90,7 +90,10 @@ class Smaky6Filesystem : public Filesystem
             uint16_t loadAddr  = ((uint16_t)loadHi  << 8) | loadLo;
             uint16_t entryAddr = ((uint16_t)entryHi << 8) | entryLo;
 
-            file_type = TYPE_FILE;
+            /* DR entries are sub-directory containers, not plain files. */
+            file_type = (filename.size() > 3 &&
+                         filename.substr(filename.size() - 3) == ".DR")
+                        ? TYPE_DIRECTORY : TYPE_FILE;
             /* When lastSectorLength == 0 the last sector is completely full;
              * FluxEngine's original formula subtracted 256 bytes in that case. */
             length = lastSectorLength
@@ -132,23 +135,20 @@ class Smaky6Filesystem : public Filesystem
     class Directory
     {
     public:
+        /* Root directory: reads the 3-sector directory area at sector 0. */
         Directory(Smaky6Filesystem* fs)
         {
-            /* Read the directory. */
-
             auto bytes = fs->getLogicalSector(0, 3);
-            ByteReader br(bytes);
+            parseFrom(bytes, 0);
+        }
 
-            for (int i = 0; i < 32; i++)
-            {
-                auto dbuf = bytes.slice(i * 0x18, 0x18);
-                /* 0x00 = empty slot; 0xFF = deleted entry (used by system files) */
-                if (dbuf[0] && dbuf[0] != 0xff)
-                {
-                    auto de = std::make_shared<SmakyDirent>(dbuf);
-                    dirents.push_back(de);
-                }
-            }
+        /* Sub-directory inside a DR container:
+         * The first 3 sectors of the DR entry hold the sub-directory.
+         * Sector numbers stored there are relative to drStartSector. */
+        Directory(Smaky6Filesystem* fs, unsigned drStartSector)
+        {
+            auto bytes = fs->getLogicalSector(drStartSector, 3);
+            parseFrom(bytes, drStartSector);
         }
 
         std::shared_ptr<SmakyDirent> findFile(const std::string& filename)
@@ -158,6 +158,25 @@ class Smaky6Filesystem : public Filesystem
                     return de;
 
             throw FileNotFoundException();
+        }
+
+    private:
+        void parseFrom(const Bytes& bytes, unsigned sectorBase)
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                auto dbuf = bytes.slice(i * 0x18, 0x18);
+                /* 0x00 = empty slot; 0xFF = deleted entry */
+                if (dbuf[0] && dbuf[0] != 0xff)
+                {
+                    auto de = std::make_shared<SmakyDirent>(dbuf);
+                    /* Sub-directory entries use relative sector numbers;
+                     * add the DR container's base sector to get absolute ones. */
+                    de->startSector += sectorBase;
+                    de->endSector   += sectorBase;
+                    dirents.push_back(de);
+                }
+            }
         }
 
     public:
@@ -200,37 +219,85 @@ public:
 
     std::vector<std::shared_ptr<Dirent>> list(const Path& path) override
     {
-        if (!path.empty())
-            throw FileNotFoundException();
-
-        Directory dir(this);
         std::vector<std::shared_ptr<Dirent>> result;
-        for (auto& de : dir.dirents)
-            result.push_back(de);
-        return result;
+
+        if (path.empty())
+        {
+            /* List the root directory. */
+            Directory dir(this);
+            for (auto& de : dir.dirents)
+                result.push_back(de);
+            return result;
+        }
+
+        if (path.size() == 1)
+        {
+            /* Listing a DR sub-directory. */
+            Directory root(this);
+            auto parent = root.findFile(path[0]);
+            if (parent->file_type != TYPE_DIRECTORY)
+                throw BadPathException(path);
+            Directory sub(this, parent->startSector);
+            for (auto& de : sub.dirents)
+                result.push_back(de);
+            return result;
+        }
+
+        throw BadPathException(path);
     }
 
     std::shared_ptr<Dirent> getDirent(const Path& path) override
     {
-        Directory dir(this);
-        if (path.size() != 1)
-            throw BadPathException();
+        if (path.size() == 1)
+        {
+            Directory dir(this);
+            return dir.findFile(path[0]);
+        }
 
-        return dir.findFile(path[0]);
+        if (path.size() == 2)
+        {
+            Directory root(this);
+            auto parent = root.findFile(path[0]);
+            if (parent->file_type != TYPE_DIRECTORY)
+                throw BadPathException(path);
+            Directory sub(this, parent->startSector);
+            return sub.findFile(path[1]);
+        }
+
+        throw BadPathException(path);
     }
 
     Bytes getFile(const Path& path) override
     {
-        if (path.size() != 1)
-            throw BadPathException(path);
+        if (path.size() == 1)
+        {
+            Directory dir(this);
+            auto de = dir.findFile(path[0]);
+            if (de->file_type == TYPE_DIRECTORY)
+                throw BadPathException(path);
+            Bytes data = getLogicalSector(
+                de->startSector, de->endSector - de->startSector);
+            return data.slice(0, de->length);
+        }
 
-        Directory dir(this);
-        auto de = dir.findFile(path[0]);
+        if (path.size() == 2)
+        {
+            Directory root(this);
+            auto parent = root.findFile(path[0]);
+            if (parent->file_type != TYPE_DIRECTORY)
+                throw BadPathException(path);
+            /* Sub-directory occupies the first 3 sectors of the DR entry;
+             * file data starts at sector 3 (relative to parent->startSector),
+             * but startSector in the sub-entry has already been made absolute
+             * by Directory::parseFrom, so we read directly. */
+            Directory sub(this, parent->startSector);
+            auto de = sub.findFile(path[1]);
+            Bytes data = getLogicalSector(
+                de->startSector, de->endSector - de->startSector);
+            return data.slice(0, de->length);
+        }
 
-        Bytes data =
-            getLogicalSector(de->startSector, de->endSector - de->startSector);
-        data = data.slice(0, de->length);
-        return data;
+        throw BadPathException(path);
     }
 
 private:

--- a/lib/vfs/smaky6fs.cc
+++ b/lib/vfs/smaky6fs.cc
@@ -135,17 +135,9 @@ class Smaky6Filesystem : public Filesystem
     class Directory
     {
     public:
-        /* Root directory: reads the 3-sector directory area at sector 0. */
-        Directory(Smaky6Filesystem* fs)
-        {
-            auto bytes = fs->getLogicalSector(0, 3);
-            parseFrom(bytes, 0);
-        }
-
-        /* Sub-directory inside a DR container:
-         * The first 3 sectors of the DR entry hold the sub-directory.
-         * Sector numbers stored there are relative to drStartSector. */
-        Directory(Smaky6Filesystem* fs, unsigned drStartSector)
+        /* drStartSector=0 reads the root directory; any other value reads
+         * the sub-directory stored in the first 3 sectors of a DR entry. */
+        Directory(Smaky6Filesystem* fs, unsigned drStartSector = 0)
         {
             auto bytes = fs->getLogicalSector(drStartSector, 3);
             parseFrom(bytes, drStartSector);
@@ -220,87 +212,54 @@ public:
     std::vector<std::shared_ptr<Dirent>> list(const Path& path) override
     {
         std::vector<std::shared_ptr<Dirent>> result;
-
-        if (path.empty())
-        {
-            /* List the root directory. */
-            Directory dir(this);
-            for (auto& de : dir.dirents)
-                result.push_back(de);
-            return result;
-        }
-
-        if (path.size() == 1)
-        {
-            /* Listing a DR sub-directory. */
-            Directory root(this);
-            auto parent = root.findFile(path[0]);
-            if (parent->file_type != TYPE_DIRECTORY)
-                throw BadPathException(path);
-            Directory sub(this, parent->startSector);
-            for (auto& de : sub.dirents)
-                result.push_back(de);
-            return result;
-        }
-
-        throw BadPathException(path);
+        for (auto& de : directoryAt(path).dirents)
+            result.push_back(de);
+        return result;
     }
 
     std::shared_ptr<Dirent> getDirent(const Path& path) override
     {
-        if (path.size() == 1)
-        {
-            Directory dir(this);
-            return dir.findFile(path[0]);
-        }
-
-        if (path.size() == 2)
-        {
-            Directory root(this);
-            auto parent = root.findFile(path[0]);
-            if (parent->file_type != TYPE_DIRECTORY)
-                throw BadPathException(path);
-            Directory sub(this, parent->startSector);
-            return sub.findFile(path[1]);
-        }
-
-        throw BadPathException(path);
+        return resolveDirent(path);
     }
 
     Bytes getFile(const Path& path) override
     {
-        if (path.size() == 1)
-        {
-            Directory dir(this);
-            auto de = dir.findFile(path[0]);
-            if (de->file_type == TYPE_DIRECTORY)
-                throw BadPathException(path);
-            Bytes data = getLogicalSector(
-                de->startSector, de->endSector - de->startSector);
-            return data.slice(0, de->length);
-        }
-
-        if (path.size() == 2)
-        {
-            Directory root(this);
-            auto parent = root.findFile(path[0]);
-            if (parent->file_type != TYPE_DIRECTORY)
-                throw BadPathException(path);
-            /* Sub-directory occupies the first 3 sectors of the DR entry;
-             * file data starts at sector 3 (relative to parent->startSector),
-             * but startSector in the sub-entry has already been made absolute
-             * by Directory::parseFrom, so we read directly. */
-            Directory sub(this, parent->startSector);
-            auto de = sub.findFile(path[1]);
-            Bytes data = getLogicalSector(
-                de->startSector, de->endSector - de->startSector);
-            return data.slice(0, de->length);
-        }
-
-        throw BadPathException(path);
+        auto de = resolveDirent(path);
+        if (de->file_type == TYPE_DIRECTORY)
+            throw BadPathException(path);
+        Bytes data = getLogicalSector(
+            de->startSector, de->endSector - de->startSector);
+        return data.slice(0, de->length);
     }
 
 private:
+    /* Returns the Directory whose entries are named by path.
+     * path=[] → root; path=["DIR.DR"] → DR sub-directory.
+     * The Smaky 6 FS is at most two levels deep; deeper paths are invalid. */
+    Directory directoryAt(const Path& path)
+    {
+        if (path.empty())
+            return Directory(this);
+        if (path.size() == 1)
+        {
+            auto parent = Directory(this).findFile(path[0]);
+            if (parent->file_type != TYPE_DIRECTORY)
+                throw BadPathException(path);
+            return Directory(this, parent->startSector);
+        }
+        throw BadPathException(path);
+    }
+
+    /* Resolves a full path to its SmakyDirent.
+     * path=["FILE"] → file in root; path=["DIR.DR","FILE"] → file in sub-dir. */
+    std::shared_ptr<SmakyDirent> resolveDirent(const Path& path)
+    {
+        if (path.empty())
+            throw BadPathException(path);
+        Path parentPath(path.begin(), path.end() - 1);
+        return directoryAt(parentPath).findFile(path.back());
+    }
+
     const Smaky6FsProto& _config;
 };
 


### PR DESCRIPTION
Three bugs in `lib/vfs/smaky6fs.cc` found by cross-referencing the original Smaky 6 hardware documentation and independent reverse-engineering of disk images (including Winchester hard-disk images not previously analysed).

## Bug 1 — Wrong file size when last sector is completely full

When `last_bytes == 0` the last sector holds a full 256 bytes. The old formula:
```c
length = (endSector - startSector - 1) * 256 + lastSectorLength;
```
gives a result **256 bytes short** in that case. Fixed to:
```c
length = lastSectorLength
    ? (endSector - startSector - 1) * 256 + lastSectorLength
    : (endSector - startSector) * 256;
```

## Bug 2 — Deleted entries with first byte `0xFF` were not skipped

The original check `if (dbuf[0])` only skips empty slots (first byte = `0x00`). On real Smaky 6 disks and all known Winchester hard-disk images, deleted/system entries use `0xFF` as a sentinel. This caused those entries to be parsed as live files with garbage field values.

Fixed to: `if (dbuf[0] && dbuf[0] != 0xff)`

## Bug 3 — Directory bytes `[0x0e–0x17]` were treated as unknown

These fields are fully decodable (documented in the original Smaky 6 hardware manual and confirmed from disk image analysis):

| Offset | Field | Notes |
|--------|-------|-------|
| `0x0e–0x0f` | `flags` | uint16 LE, purpose TBD |
| `0x10–0x11` | `last_bytes` | bytes used in last sector (0 = full) |
| `0x12–0x13` | `load_addr` | high byte then low byte; reliable for type `SM` |
| `0x14–0x15` | `entry_addr` | same encoding as load_addr |
| `0x16` | `month` | BCD (e.g. `0x07` = July); `0x00` or `0xFF` = no date |
| `0x17` | `year` | BCD (e.g. `0x82` = 1982); year ≥ 78 → 19xx, else 20xx |

The raw `smaky6.metadata_bytes` attribute is replaced by the properly decoded `smaky6.flags`, `smaky6.load_addr`, `smaky6.entry_addr`, and `smaky6.date` attributes.