### PR TITLE
Makefile: Fix auto-detection of Windows environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 ifeq ($(BUILDTYPE),)
+    # On MSYS2 uname -s produces something like: MINGW64_NT-10.0-19045
+    # Strip the suffix off
+    OS := $(patsubst MINGW%,MINGW,$(shell uname -s))
     buildtype_Darwin = osx
     buildtype_Haiku = haiku
-    BUILDTYPE := $(buildtype_$(shell uname -s ))
+    buildtype_MINGW = windows
+    BUILDTYPE := $(buildtype_$(OS))
         ifeq ($(BUILDTYPE),)
                 BUILDTYPE := unix
         endif


### PR DESCRIPTION
Plain "make" now works correctly in MSY2/Mingw64 shell for Windows build. No more need to explicitly provide BUILDTYPE=windows.