### PR TITLE
Introduce TR-DOS disk format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ choices because they can store multiple types of file system.
 | [`ti99`](doc/disk-ti99.md) | TI-99: 90kB 35-track SSSD | 🦖 |  |  |
 | [`tids990`](doc/disk-tids990.md) | Texas Instruments DS990: 1126kB 8" DSSD | 🦖 | 🦖 |  |
 | [`tiki`](doc/disk-tiki.md) | Tiki 100: CP/M |  |  | CPMFS  |
+| [`trdos`](doc/disk-trdos.md) | TR-DOS: TR-DOS for ZX-Spectrum BetaDisc interface | 🦄 | 🦄 |  |
 | [`victor9k`](doc/disk-victor9k.md) | Victor 9000 / Sirius One: 1224kB 5.25" DSDD GCR | 🦖 | 🦖 |  |
 | [`zilogmcz`](doc/disk-zilogmcz.md) | Zilog MCZ: 320kB 8" 77-track SSSD hard-sectored | 🦖 |  | ZDOS  |
 {: .datatable }

--- a/lib/config/config.cc
+++ b/lib/config/config.cc
@@ -157,6 +157,7 @@ static const std::vector<ImageConstructor> imageConstructors = {
     {".nsi",      IMAGETYPE_NSI,      MODE_RW},
     {".st",       IMAGETYPE_IMG,      MODE_RW},
     {".td0",      IMAGETYPE_TD0,      MODE_RO},
+    {".trd",      IMAGETYPE_IMG,      MODE_RW},
     {".vgi",      IMAGETYPE_IMG,      MODE_RW},
     {".xdf",      IMAGETYPE_IMG,      MODE_RW},
 };

--- a/src/formats/build.py
+++ b/src/formats/build.py
@@ -37,6 +37,7 @@ formats = [
     "ti99",
     "tids990",
     "tiki",
+    "trdos",
     "victor9k",
     "zilogmcz",
 ]

--- a/src/formats/trdos.textpb
+++ b/src/formats/trdos.textpb
@@ -1,0 +1,125 @@
+shortname: 'TR-DOS'
+comment: 'TR-DOS for ZX-Spectrum BetaDisc interface'
+read_support_status: UNICORN
+write_support_status: UNICORN
+
+documentation:
+<<<
+BetaDisc interface for the ZX-Spectrum by Technology research came with a simple
+operating system in ROM named TR-DOS. The controller is a standard 1793 chip,
+widespread at the time. 40 or 80 tracks, one or two sides, 16 sectors per track,
+sector size is 256 bytes. Side byte in sector ID record is not used and always
+set to 0.
+
+FluxEngine can read these.
+>>>
+
+image_reader {
+	filename: "trdos.trd"
+	type: IMAGETYPE_IMG
+}
+
+image_writer {
+	filename: "trdos.trd"
+	type: IMAGETYPE_IMG
+}
+
+decoder {
+	ibm {
+		trackdata {
+			ignore_side_byte: true
+		}
+	}
+}
+
+encoder {
+  	ibm {
+    	trackdata {
+      		emit_iam: false
+			gap0: 10
+			gap2: 22
+			gap3: 60
+    	}
+  	}
+}
+
+option_group {
+	comment: "$formats"
+
+	option {
+		name: "640DSDD"
+		comment: '80-track double-sided'
+
+		config {
+			layout {
+				format_type: FORMATTYPE_80TRACK
+				tracks: 80
+				sides: 2
+				layoutdata {
+					sector_size: 256
+					physical {
+						start_sector: 1
+						count: 16
+					}
+				}
+			}
+		}
+	}
+	option {
+		name: "320SSDD"
+		comment: '80-track single-sided'
+
+		config {
+			layout {
+				format_type: FORMATTYPE_80TRACK
+				tracks: 80
+				sides: 1
+				layoutdata {
+					sector_size: 256
+					physical {
+						start_sector: 1
+						count: 16
+					}
+				}
+			}
+		}
+	}
+	option {
+		name: "320DSDD"
+		comment: '40-track double-sided'
+
+		config {
+			layout {
+				format_type: FORMATTYPE_40TRACK
+				tracks: 40
+				sides: 2
+				layoutdata {
+					sector_size: 256
+					physical {
+						start_sector: 1
+						count: 16
+					}
+				}
+			}
+		}
+	}
+	option {
+		name: "160SSDD"
+		comment: '40-track single-sided'
+
+		config {
+			layout {
+				format_type: FORMATTYPE_40TRACK
+				tracks: 40
+				sides: 1
+				layoutdata {
+					sector_size: 256
+					physical {
+						start_sector: 1
+						count: 16
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
TR-DOS is a built-in ROM-based operating system for BetaDisk interface for the ZX-Spectrum by Technology Research Ltd. In late 80s it was brought into (back-then) USSR and cloned, having become a de-facto standard floppy disk interface for ZX-spectrum clones.
Official documentation says both 40- and 80- single- and double- sided drives are supported, however in practice i never met any other formats than 80-track DS. The controller is off-the-shelf 1793 chip, so encoding scheme it a standard IBM-compatible MFM. Sector size is 256 bytes, 16 sectors per track.
Official extension for plain TR-DOS disk images is .trd, so i added it to the list of recognized extensions by IMG writer.

Tested with real hardware by successfully reading a disk, written from .trd image using Fluxengine with Greaseweasle.