### PR TITLE
[HOTFIX] lib/vfs: Fix build error

### DIFF
--- a/lib/vfs/vfs.cc
+++ b/lib/vfs/vfs.cc
@@ -23,6 +23,11 @@ Path::Path(const std::vector<std::string> other):
 {
 }
 
+Path::Path(const std::vector<std::string>::const_iterator& begin, const std::vector<std::string>::const_iterator& end):
+    std::vector<std::string>(begin, end)
+{
+}
+
 Path::Path(const std::string& path)
 {
     if (path == "")


### PR DESCRIPTION
The error was introduced by a4a56ddd674d8c206498995586019da93aec0b8e:

lib/vfs/smaky6fs.cc:259:53: error: no matching function for call to 'Path::Path(std::vector<std::__cxx11::basic_string<char> >::const_iterator, __gnu_cxx::__normal_iterator<const std::__cxx11::basic_string<char>*, std::vector<std::__cxx11::basic_string<char> > >)'
  259 |         Path parentPath(path.begin(), path.end() - 1);
      |                                                     ^

The new code requires a new Path ctor to be exposed, was probably forgotten.


(cherry picked from commit 11735e89a904bda62ae3f8640952f0aecbe079f3)